### PR TITLE
fix(broadcast): mirror host output as text, not raw PTY bytes

### DIFF
--- a/client/src/views/ViewBroadcast.tsx
+++ b/client/src/views/ViewBroadcast.tsx
@@ -6,8 +6,14 @@
 // tile mirrors its host's live PTY output; the bottom bar fans the typed command
 // out to all open hosts via api.broadcastWriteAll. Status comes ONLY from the
 // live terminals (statuses[i].connected) — no fake online/ping/cipher.
+//
+// A tile is plain text, not a terminal emulator, so raw PTY bytes cannot go into
+// it as-is: they carry colour/OSC escapes, rewrite lines with bare CRs, and split
+// multi-byte characters across reads. Each host therefore gets its own
+// createPreviewCapture — the same decode/strip/CR pipeline the hosts rail uses,
+// asked for a deeper tail — rather than a fourth hand-rolled parser here.
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "@/i18n";
 import { usePalette } from "@/theme/ThemeProvider";
 import { MONO } from "@/theme/tokens";
@@ -16,6 +22,7 @@ import { useApp, type PendingMismatch } from "@/store/app";
 import { useIsMobile, useNarrow } from "@/store/responsive";
 import { toast } from "@/store/toast";
 import { guard } from "@/store/action";
+import { createPreviewCapture, type PreviewCapture } from "@/views/terminal/paneSession";
 import * as api from "@/bridge/api";
 import {
   apiErrorMessage,
@@ -30,18 +37,18 @@ const TERM = "xterm-256color";
 const COLS = 80;
 const ROWS = 24;
 const TAIL_LINES = 6;
+/** Stable empty tail, so a host that hasn't spoken yet keeps a stable prop. */
+const EMPTY_LINES: string[] = [];
+// A live mirror, not a glanceable preview: the rail's half-second reads as lag
+// when you are watching your own keystrokes land. Still batched, because one
+// broadcast command makes every host talk at once — this cuts the great majority
+// of the re-renders a per-read update would cause, without being visible.
+const MIRROR_DEBOUNCE_MS = 100;
 
 // Obviously-destructive verbs — typing one into a fan-out-to-many-live-hosts bar
 // always re-confirms, even after the session's first send has been confirmed.
 const BROADCAST_DANGER =
   /(\brm\s+-\w*[rf]|\breboot\b|\bshutdown\b|\bhalt\b|\bpoweroff\b|\bmkfs|\bdd\s+if=|:\(\)\s*\{|>\s*\/dev\/)/i;
-
-/** Keep only the last N non-trailing-empty lines of a mirrored buffer. */
-function tail(buf: string, n: number): string[] {
-  const lines = buf.split(/\r?\n/);
-  while (lines.length > 1 && lines[lines.length - 1] === "") lines.pop();
-  return lines.slice(-n);
-}
 
 interface OpenedHost {
   index: number;
@@ -49,13 +56,17 @@ interface OpenedHost {
   status: BroadcastHostStatus;
 }
 
-function HostTile({
+// Memoised: every host answers a broadcast at once, so an unmemoised tile makes
+// each host's update re-render all N of them. Holds because a data event touches
+// only that host's `mirrored` array — `host` and the callback keep their identity.
+const HostTile = memo(function HostTile({
   host,
-  output,
+  mirrored,
   onReviewMismatch,
 }: {
   host: OpenedHost;
-  output: string;
+  /** The host's last mirrored lines, already decoded and stripped of escapes. */
+  mirrored: string[];
   /** The host failed to open because its pinned key changed — offer the Known
    *  hosts ceremony with the PARSED failing-hop host/port/fingerprint (a jump
    *  host isn't the profile), so the caller pins the right key. */
@@ -64,7 +75,7 @@ function HostTile({
   const p = usePalette();
   const { t } = useTranslation();
   const off = !host.status.connected;
-  const lines = off ? [] : tail(output, TAIL_LINES);
+  const lines = off ? [] : mirrored;
   const mismatch = off ? mismatchFromError(host.status.error) : null;
   return (
     <div
@@ -148,7 +159,7 @@ function HostTile({
       </div>
     </div>
   );
-}
+});
 
 export function ViewBroadcast() {
   const p = usePalette();
@@ -182,13 +193,21 @@ export function ViewBroadcast() {
 
   const [bcId, setBcId] = useState<string | null>(null);
   const [opened, setOpened] = useState<OpenedHost[]>([]);
-  const [outputs, setOutputs] = useState<Record<number, string>>({});
+  const [outputs, setOutputs] = useState<Record<number, string[]>>({});
   const [typed, setTyped] = useState("");
   const [busy, setBusy] = useState(false);
   const [caret, setCaret] = useState(true);
 
   const bcIdRef = useRef<string | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
+  // One capture per host index, created on that host's first byte. Each owns a
+  // streaming decoder and a debounce timer, so they must be disposed whenever
+  // the session they belong to goes away.
+  const capturesRef = useRef(new Map<number, PreviewCapture>());
+  const disposeCaptures = useCallback(() => {
+    capturesRef.current.forEach((c) => c.dispose());
+    capturesRef.current.clear();
+  }, []);
 
   // blinking caret (prototype cadence)
   useEffect(() => {
@@ -199,13 +218,14 @@ export function ViewBroadcast() {
   // close the broadcast on unmount
   useEffect(() => {
     return () => {
+      disposeCaptures();
       const id = bcIdRef.current;
       if (id) {
         void api.broadcastClose(id);
         useApp.getState().removeBroadcast(id);
       }
     };
-  }, []);
+  }, [disposeCaptures]);
 
   // Guard nav away from this view while any host is live: leaving unmounts the view
   // and tears the whole broadcast down, so route it through a confirm first. Cleared
@@ -243,12 +263,13 @@ export function ViewBroadcast() {
     }
     const id = bcIdRef.current;
     if (id) useApp.getState().removeBroadcast(id); // already closed by setVault
+    disposeCaptures();
     bcIdRef.current = null;
     setBcId(null);
     setOpened([]);
     setOutputs({});
     setTyped("");
-  }, [vaultId]);
+  }, [vaultId, disposeCaptures]);
 
   const liveCount = opened.filter((h) => h.status.connected).length;
   // Hosts the Connect action will actually open — the button carries this count.
@@ -319,8 +340,15 @@ export function ViewBroadcast() {
       await guard(async () => {
         const onEvent = (e: BroadcastEvent) => {
           if (e.type === "data") {
-            const text = new TextDecoder().decode(new Uint8Array(e.bytes));
-            setOutputs((prev) => ({ ...prev, [e.index]: (prev[e.index] ?? "") + text }));
+            let cap = capturesRef.current.get(e.index);
+            if (!cap) {
+              cap = createPreviewCapture(
+                (lines) => setOutputs((prev) => ({ ...prev, [e.index]: lines })),
+                { show: TAIL_LINES, debounceMs: MIRROR_DEBOUNCE_MS },
+              );
+              capturesRef.current.set(e.index, cap);
+            }
+            cap.push(new Uint8Array(e.bytes));
           } else {
             setOpened((prev) =>
               prev.map((h) =>
@@ -337,6 +365,8 @@ export function ViewBroadcast() {
         // one (the vault-change effect already reset our local state).
         if (useApp.getState().vaultId !== vaultId) {
           void api.broadcastClose(res.id);
+          // Captures the abandoned hosts may already have created during the open.
+          disposeCaptures();
           return;
         }
         const map = new Map(res.statuses.map((s) => [s.index, s]));
@@ -547,7 +577,7 @@ export function ViewBroadcast() {
               <HostTile
                 key={h.index}
                 host={h}
-                output={outputs[h.index] ?? ""}
+                mirrored={outputs[h.index] ?? EMPTY_LINES}
                 onReviewMismatch={onReviewMismatch}
               />
             ))}

--- a/client/src/views/terminal/paneSession.test.ts
+++ b/client/src/views/terminal/paneSession.test.ts
@@ -86,6 +86,66 @@ describe("createPreviewCapture", () => {
     vi.runAllTimers();
     expect(emit).not.toHaveBeenCalled();
   });
+
+  it("emits as many lines as the caller asked for", () => {
+    // The broadcast grid mirrors a deeper tail than the hosts rail does.
+    const emit = vi.fn();
+    const cap = createPreviewCapture(emit, { show: 6 });
+    cap.push(enc("a\r\nb\r\nc\r\nd\r\ne\r\nf\r\ng\r\nh\r\n"));
+    vi.runAllTimers();
+    expect(emit).toHaveBeenCalledWith(["c", "d", "e", "f", "g", "h"]);
+  });
+
+  it("emits on the caller's debounce, not the rail's", () => {
+    // The broadcast grid is a live mirror; the rail is glanced at. Same pipeline,
+    // different cadence.
+    const emit = vi.fn();
+    const cap = createPreviewCapture(emit, { debounceMs: 100 });
+    cap.push(enc("quick\r\n"));
+    vi.advanceTimersByTime(100);
+    expect(emit).toHaveBeenCalledWith(["quick"]);
+  });
+
+  it("defaults to the rail's slower cadence", () => {
+    const emit = vi.fn();
+    const cap = createPreviewCapture(emit);
+    cap.push(enc("slow\r\n"));
+    vi.advanceTimersByTime(100);
+    expect(emit).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(400);
+    expect(emit).toHaveBeenCalledWith(["slow"]);
+  });
+
+  it("mirrors a real send: echo, output and prompt redraw, no control codes", () => {
+    // What a bash host actually writes back after a broadcast send — bracketed
+    // paste off/on, an OSC title, a colour-coded prompt, and a \r-rewritten
+    // progress line. None of it may reach a plain-text tile as literal text.
+    const emit = vi.fn();
+    const cap = createPreviewCapture(emit, { show: 6 });
+    cap.push(enc("uptime\r\n\x1b[?2004l\r"));
+    cap.push(enc(" 14:22:01 up 12 days,  3:11,  2 users\r\n"));
+    cap.push(enc("sync: 10%\rsync: 60%\rsync: 100%\r\n"));
+    cap.push(enc("\x1b]0;root@web-01: ~\x07\x1b[?2004h\x1b[01;32mroot@web-01\x1b[00m:~$ "));
+    vi.runAllTimers();
+    expect(emit).toHaveBeenCalledWith([
+      "uptime",
+      " 14:22:01 up 12 days,  3:11,  2 users",
+      "sync: 100%",
+      "root@web-01:~$",
+    ]);
+  });
+
+  it("decodes multi-byte characters split across reads", () => {
+    // A PTY read can end mid-character; decoding each chunk on its own turns
+    // the halves into U+FFFD.
+    const emit = vi.fn();
+    const cap = createPreviewCapture(emit);
+    const utf8 = enc("Загрузка\r\n");
+    cap.push(utf8.slice(0, 5));
+    cap.push(utf8.slice(5));
+    vi.runAllTimers();
+    expect(emit).toHaveBeenCalledWith(["Загрузка"]);
+  });
 });
 
 describe("createPaneEvents", () => {

--- a/client/src/views/terminal/paneSession.ts
+++ b/client/src/views/terminal/paneSession.ts
@@ -32,8 +32,9 @@ export function shouldRetryOnResume(pane: TerminalPaneState): boolean {
 /** How many recent output lines the rail preview keeps, and how many it shows. */
 const PREVIEW_KEEP = 6;
 const PREVIEW_SHOW = 3;
-/** Debounce for pushing the preview into the store — a busy session would
- *  otherwise re-render the hosts rail on every read. */
+/** Default debounce for pushing the preview into the store — a busy session
+ *  would otherwise re-render the hosts rail on every read. Callers that render
+ *  a live mirror rather than a glanceable preview override it. */
 const PREVIEW_DEBOUNCE_MS = 500;
 
 const stripAnsi = (str: string): string =>
@@ -54,10 +55,26 @@ export interface PreviewCapture {
   dispose: () => void;
 }
 
+export interface PreviewOptions {
+  /** How many lines each emit carries. Defaults to the hosts rail's three; the
+   *  broadcast grid mirrors a deeper tail into a taller tile. */
+  show?: number;
+  /** How long output is batched before an emit. The default suits a surface
+   *  glanced at from the side; a live mirror wants a shorter one, and pays for
+   *  it in re-renders. */
+  debounceMs?: number;
+}
+
 /** Keeps a rolling window of recent output lines so the hosts-rail shows a
  *  stable multi-line preview: real output, debounced, rather than the latest
  *  tail (which at an idle prompt would collapse to one line). */
-export function createPreviewCapture(emit: (lines: string[]) => void): PreviewCapture {
+export function createPreviewCapture(
+  emit: (lines: string[]) => void,
+  opts: PreviewOptions = {},
+): PreviewCapture {
+  const show = opts.show ?? PREVIEW_SHOW;
+  const keep = Math.max(PREVIEW_KEEP, show);
+  const debounceMs = opts.debounceMs ?? PREVIEW_DEBOUNCE_MS;
   const decoder = new TextDecoder();
   let partial = ""; // an incomplete trailing line, carried to the next read
   let lines: string[] = [];
@@ -75,7 +92,7 @@ export function createPreviewCapture(emit: (lines: string[]) => void): PreviewCa
         const clean = stripAnsi(lastLine(raw)).replace(/\s+$/, "");
         if (clean.trim().length) {
           lines.push(clean);
-          if (lines.length > PREVIEW_KEEP) lines = lines.slice(-PREVIEW_KEEP);
+          if (lines.length > keep) lines = lines.slice(-keep);
         }
       }
       if (timer != null) return;
@@ -83,8 +100,8 @@ export function createPreviewCapture(emit: (lines: string[]) => void): PreviewCa
         timer = null;
         const tail = stripAnsi(lastLine(partial)).replace(/\s+$/, "");
         const all = tail.trim().length ? [...lines, tail] : lines;
-        emit(all.slice(-PREVIEW_SHOW));
-      }, PREVIEW_DEBOUNCE_MS);
+        emit(all.slice(-show));
+      }, debounceMs);
     },
     dispose() {
       if (timer != null) {


### PR DESCRIPTION
## Summary

A broadcast tile is plain text, not a terminal emulator, but it was fed the
session's PTY bytes verbatim. Three kinds of rubbish reached the screen:

| | before | after |
|---|---|---|
| escapes | `]0;root@web-01: ~[?2004h[01;32mroot@web-01…` | `root@web-01:~$` |
| carriage return | `sync: 10%\rsync: 60%\rsync: 100%` on one line | `sync: 100%` |
| multi-byte split across reads | `За��рузка` | `Загрузка` |

(That table is the real output of the old pipeline and the new one, fed the same
recorded transcript.)

The causes, in order: nothing stripped ANSI/OSC sequences; the tail split on
`\n` alone, so a bare `\r` stayed embedded in the line instead of rewriting it;
and a fresh `TextDecoder` per read turned any character straddling a chunk
boundary into U+FFFD.

**All three were already solved once**, for the hosts rail, by
`createPreviewCapture` — streaming decode, escape stripping, and the rule that
only what follows the last `\r` is visible. Broadcast now uses it rather than a
fourth hand-rolled parser. It needs two things the rail does not, so both became
parameters: a deeper tail (6 lines, not 3) and a shorter cadence — a live mirror
cannot wait the half-second a glanced-at preview can, so the debounce drops to
100 ms here. The rail keeps its old default, pinned by a test so a future tweak
on this side cannot quietly slow it down.

The tile is memoised on the way past. One broadcast command makes every host
answer at once, and an unmemoised tile turned each host's update into a
re-render of all of them. **Net effect is fewer re-renders than before this
fix**, which updated the whole grid on every read — and a per-host buffer that
is now a rolling six lines instead of one that grew for the life of the session.

## Linked issue

No tracking issue — reported directly as "weird characters when you send a
command".

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior/format/protocol)
- [ ] Docs only
- [ ] Build / CI / deps / tooling
- [ ] Refactor (no functional change)

## Checklist

- [x] `cargo fmt --all --check` passes (or `just lint`) — n/a, no Rust touched.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes — n/a, no Rust touched.
- [x] `cargo test --workspace` passes — n/a, no Rust touched.
- [x] If I touched the admin panel, `just build-ui` still builds the wasm bundle + SPA — n/a, admin panel untouched.
- [x] Changes stay **within one component's boundary** — three files under `client/src`.
- [x] **No core logic is duplicated** — the point of the change is to *stop* duplicating a parser the client already has.
- [x] **No plaintext private keys cross the core↔UI/FFI boundary** — this only renders session output.
- [x] Docs updated where relevant — none needed; no user-facing surface or option changes.

## Notes for reviewers

Verified locally: `npx vitest run` 310/310 green, `tsc --noEmit` clean, eslint
clean on the three files. Three of the new tests are worth a look — one for the
cadence parameter and one for a multi-byte character split across reads both
**failed before the change and pass after**; a third feeds a realistic bash
transcript (bracketed paste, OSC title, colour-coded prompt, `\r`-rewritten
progress line) through the pipeline and pins the result.

Two things I did **not** verify, stated plainly:

- **The 100 ms cadence has not been felt in a running app.** It is a judgement
  that it reads as instant while still batching; only a real run against
  talkative hosts settles it. It is one constant, `MIRROR_DEBOUNCE_MS` in
  `ViewBroadcast.tsx`.
- **Blank lines now drop out** of a tile. That is `createPreviewCapture`'s
  existing behaviour, inherited along with the rest, not a decision made here —
  worth a moment's thought on whether a 6-line tile wants it.

Also inherited, and worth knowing: `stripAnsi` covers OSC, CSI and two-byte
escapes. A DCS/APC sequence would lose its delimiters but leave its payload as
text. Not seen in shell output; not claimed to be fixed.

Out of scope, noticed nearby: the send path writes `typed + "\n"`, where a
terminal sends `\r` on Enter. Harmless for a shell in canonical mode, wrong for
anything in raw mode. Left alone deliberately — different bug, different PR.
