### PR TITLE
build(ios): put the icon step in ios-init, where it cannot be forgotten

### DIFF
--- a/justfile
+++ b/justfile
@@ -49,14 +49,28 @@ dev-ui:
     cd server-ui && npm run dev
 
 # ---------- iOS (mobile · macOS only) ----------
-# Generate the iOS Xcode project, then apply the post-gen fixups that the
-# cargo-mobile2 template otherwise breaks on recent Xcode (script-sandboxing
-# off, deployment target = tauri.conf.json minimum). Use this instead of a bare
-# `tauri ios init` — gen/apple is gitignored/regenerated, so the fixups must
-# follow every init (they survive `ios build`/`ios dev`).
+# Generate the iOS Xcode project, put OUR icons in it, then apply the post-gen
+# fixups that the cargo-mobile2 template otherwise breaks on recent Xcode
+# (script-sandboxing off, deployment target = tauri.conf.json minimum). Use this
+# instead of a bare `tauri ios init` — gen/apple is gitignored/regenerated, so
+# both the icons and the fixups must follow every init (they survive
+# `ios build`/`ios dev`).
+#
+# The icon step is not optional and its ORDER matters: `ios init` scaffolds the
+# asset catalog with TAURI'S OWN default icons, and `tauri icon` is what replaces
+# them — run the other way round there is nothing to overwrite yet. Leaving it
+# out builds an app wearing someone else's logo, which is easy to miss because
+# nothing fails. The CI job does the same two calls and then verifies every
+# scaffolded file changed (scripts/assert-icons-replaced.py); locally there is no
+# such guard, so the step lives here where it cannot be forgotten.
 ios-init:
     cd client && npm run tauri ios init
+    cd client && npm run tauri icon src-tauri/app-icon.json
     bash scripts/ios-fix-xcodeproj.sh
+# Re-apply just the icons, for a gen/apple that already exists (e.g. after Xcode
+# or Tauri reset the asset catalog).
+ios-icons:
+    cd client && npm run tauri icon src-tauri/app-icon.json
 # Re-apply the iOS Xcode-project fixups without regenerating (e.g. after Xcode
 # or Tauri reset the project).
 ios-fix:


### PR DESCRIPTION
## Summary

Reported from a local iOS build: the app came out wearing **Tauri's default
icon**, not ours.

`tauri ios init` scaffolds `gen/apple`'s asset catalog with Tauri's own default
icons. `npx tauri icon src-tauri/app-icon.json` is the *separate* call that
replaces them, and the order matters — run the other way round there is nothing
to overwrite yet.

The CI job does both, then verifies every scaffolded file changed
(`scripts/assert-icons-replaced.py`). Its comment spells out why that guard is
there: the failure is silent, and a build shipping someone else's logo goes green.

**The justfile only ever did the first call.** `tauri icon` appeared nowhere in
it, nor in any script — so a local `just ios-init && just ios-dev` reproduced
exactly the failure CI is built to prevent, with no guard to catch it. And since
`gen/apple` is gitignored and regenerated, it came back on every init.

```diff
 ios-init:
     cd client && npm run tauri ios init
+    cd client && npm run tauri icon src-tauri/app-icon.json
     bash scripts/ios-fix-xcodeproj.sh
```

Also adds **`just ios-icons`** for a `gen/apple` that already exists — the same
escape hatch `ios-fix` gives for the Xcode-project fixups, since Xcode or Tauri
can reset the asset catalog without a full re-init.

## Linked issue

No tracking issue — hit while testing a local iOS build.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior/format/protocol)
- [ ] Docs only
- [ ] Build / CI / deps / tooling
- [ ] Refactor (no functional change)

## Checklist

- [x] `cargo fmt` / `clippy` / `cargo test` — n/a, no Rust touched.
- [x] If I touched the admin panel, `just build-ui` still builds — n/a, untouched.
- [x] Changes stay **within one component's boundary** — one recipe file.
- [x] **No core logic is duplicated** — no logic here.
- [x] **No plaintext private keys cross the core↔UI/FFI boundary** — build recipe only.
- [x] Docs updated where relevant — `website/.../build.md` already points at the
      `just ios-*` targets rather than listing their steps, so it stays correct.

## Notes for reviewers

**No CI will run on this.** `justfile` is not in the `paths` filter of any
workflow — checked all five — so this PR has nothing to go green. That is worth
knowing rather than waiting for.

Verified locally as far as this machine allows: `just --list` parses and shows
both recipes. It cannot go further — the recipes are macOS-only and this box has
no Xcode; the fix itself was confirmed on the reporter's Mac, where running
`npx tauri icon src-tauri/app-icon.json` by hand produced the right icon.

Two things deliberately left alone:

- **`just --fmt --check` reports the file differs from canonical formatting.** It
  did so before this change too (the drift is in the release recipe), so
  reformatting it here would bury a one-line fix under unrelated churn.
- **`just --list` shows a truncated doc line** for these recipes — just takes the
  comment line immediately above, and every recipe in this file already reads
  that way (`build  # ---------- Rust ...`). Worth fixing across the file, not in
  one recipe.
