### PR TITLE
docs(readme): a Telegram badge in the header

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ _Your keys, your hosts, your server. No cloud account, no vendor lock-in — and
 [![Server: zero-knowledge](https://img.shields.io/badge/server-zero--knowledge-2ecc71.svg)](#security--privacy)
 [![CI](https://img.shields.io/github/actions/workflow/status/goduni/unissh/ci.yml?branch=main)](https://github.com/goduni/unissh/actions)
 [![Release](https://img.shields.io/github/v/release/goduni/unissh?display_name=tag)](https://github.com/goduni/unissh/releases)
+[![Telegram](https://img.shields.io/badge/Telegram-%40unissh-26A5E4?logo=telegram&logoColor=white)](https://t.me/unissh)
 [![Stars](https://img.shields.io/github/stars/goduni/unissh?style=social)](https://github.com/goduni/unissh)
 
 <br/>


### PR DESCRIPTION
## Summary

Adds a Telegram badge to the README's badge row, linking to [@unissh](https://t.me/unissh).

The Community section has linked the channel for a while, but it sits near the bottom of a long README — someone deciding whether the project is alive never scrolls that far. The badge row is where that question actually gets asked.

Placed next to Stars rather than among the technical badges, since it is the same kind of signal.

**Discord is not in this PR.** There is no invite link yet, and a badge pointing at nothing is worse than no badge. It goes in as a one-line follow-up once the server exists.

## Linked issue

No tracking issue — a direct request.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior/format/protocol)
- [x] Docs only
- [ ] Build / CI / deps / tooling
- [ ] Refactor (no functional change)

## Checklist

- [x] `cargo fmt` / `clippy` / `cargo test` — n/a, docs only.
- [x] If I touched the admin panel, `just build-ui` still builds — n/a.
- [x] Changes stay **within one component's boundary** — one line of README.
- [x] **No core logic is duplicated** — no code.
- [x] **No plaintext private keys cross the core↔UI/FFI boundary** — no code.
- [x] Docs updated where relevant — this is the doc.

## Notes for reviewers

Both endpoints were checked rather than assumed: `https://t.me/unissh` returns 200 with the title *Telegram: View @unissh*, and the shields.io URL returns a real `image/svg+xml` containing both "Telegram" and "unissh". Every other badge in the row was re-checked at the same time — all eight return 200.

One editorial note, not addressed here: the Community section opens with **"Two places, on purpose:"** and then argues why — Telegram for speed, Discussions for what should still be findable in a year. Adding Discord makes that three, and the sentence stops being true. Worth deciding what role Discord plays that Telegram does not before it lands, otherwise the section's own reasoning undercuts it.