### PR TITLE
ci: notify Telegram about new issues and PRs

### DIFF
--- a/.github/workflows/new-event.yml
+++ b/.github/workflows/new-event.yml
@@ -1,0 +1,27 @@
+name: Issues/PRs Notifier
+
+on:
+  issues:
+    types: [opened, reopened]
+  pull_request_target:
+    types: [opened, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  issues: read
+  pull-requests: read
+
+jobs:
+  notify:
+    name: Telegram notification
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Telegram notification for new issue or pull request
+        uses: reagento/relator@4b1531359edba1228db0906e8931b0da2aef69cd # v1.7.0
+        with:
+          tg-bot-token: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          tg-chat-id: ${{ vars.TELEGRAM_CHAT_ID }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds a dedicated GitHub Actions workflow that sends Telegram notifications when an issue or pull request is opened or reopened.

The workflow uses `reagento/relator` pinned to the `v1.7.0` commit SHA, follows the existing `unihttp` integration, and requires the `TELEGRAM_BOT_TOKEN` secret plus the `TELEGRAM_CHAT_ID` repository variable.

## Linked issue

No linked issue; this adds the requested project-notification workflow.

## Type of change

- [x] Build / CI / deps / tooling

## Checklist

- [ ] `cargo fmt --all --check` passes (or `just lint`).
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes (or `just lint`).
- [ ] `cargo test --workspace` passes.
- [ ] If I touched the admin panel, `just build-ui` still builds the wasm bundle + SPA.
- [x] Changes stay **within one component's boundary**.
- [x] **No core logic is duplicated**.
- [x] **No plaintext private keys cross the core↔UI/FFI boundary**.
- [ ] Docs updated where relevant (README / component READMEs / `website/`).
- [x] I agree my contribution is licensed under the project's dual **MIT OR Apache-2.0** license.

## Notes for reviewers

Validated the workflow YAML with Python and `actionlint`; `git diff --check` also passes.

The workflow is inactive until maintainers configure:

- Repository secret: `TELEGRAM_BOT_TOKEN`
- Repository variable: `TELEGRAM_CHAT_ID`