### PR TITLE
feat(terminal): clipboard both ways — OSC 52 copy, keyboard paste

### DIFF
--- a/client/src/views/ViewTerminal.tsx
+++ b/client/src/views/ViewTerminal.tsx
@@ -27,6 +27,7 @@ import { useIsMobile } from "@/store/responsive";
 import { splitLocalTerminal, useCtx } from "@/store/ctx";
 import { localRecordingRequest, useLocalMachine } from "@/store/localShell";
 import { createPaneEvents, type PaneEvents } from "@/views/terminal/paneSession";
+import { parseOsc52 } from "@/views/terminal/osc52";
 import * as api from "@/bridge/api";
 import { apiErrorMessage, isApiError, type ConnectionProfile } from "@/bridge/types";
 import { writeText, readText } from "@tauri-apps/plugin-clipboard-manager";
@@ -520,6 +521,16 @@ async function runStartupSnippets(
       return true;
     });
 
+    // OSC 52 — the remote side (zellij, tmux `set-clipboard on`, nvim) writing
+    // its copy into the system clipboard. Before this handler the sequence was
+    // silently dropped, and a multiplexer's own "copied to clipboard" was a lie.
+    // Write-only: the "?" read query never gets an answer (see osc52.ts).
+    term.parser.registerOscHandler(52, (data) => {
+      const text = parseOsc52(data);
+      if (text) void writeText(text);
+      return true;
+    });
+
     // Cmd+F (macOS) / Ctrl+Shift+F opens find; plain Ctrl+F is left to the shell
     // (readline forward-char). Escape closes it. attachCustomKeyEventHandler runs
     // only while THIS terminal has focus, so other panes/tabs are unaffected.
@@ -575,6 +586,17 @@ async function runStartupSnippets(
           term.clearSelection();
           return false;
         }
+      }
+      // Keyboard paste. macOS keeps ⌘V (the webview's native paste event feeds
+      // xterm) and is left alone — a second handler there would double-paste.
+      // On Linux/Windows both Ctrl+V and Ctrl+Shift+V paste: WebView2 never
+      // delivers a native paste to the xterm textarea, so Windows had no
+      // keyboard paste at all (#29), and returning false stops the platforms
+      // that DO have a native path from pasting twice. This spends readline's
+      // quoted-insert (^V) — deliberate, the Termius trade.
+      if (!isMac() && (ev.key === "v" || ev.key === "V") && ev.ctrlKey && !ev.altKey && !ev.metaKey) {
+        if (ev.type === "keydown") void pasteClipboard();
+        return false;
       }
       return true;
     });

--- a/client/src/views/terminal/osc52.test.ts
+++ b/client/src/views/terminal/osc52.test.ts
@@ -1,0 +1,54 @@
+// OSC 52 is how a remote multiplexer/editor (zellij, tmux, nvim) asks the
+// terminal to write its selection into the system clipboard. The payload
+// reaches us as `Pc;Pd` — selection targets, then base64 text. Getting this
+// wrong either drops the user's copy on the floor (the bug this fixes) or
+// hands the remote host a clipboard-read primitive (the "?" query), so the
+// accept/reject line is worth pinning.
+
+import { describe, expect, it } from "vitest";
+import { parseOsc52, OSC52_MAX_B64 } from "./osc52";
+
+const b64 = (s: string): string => btoa(String.fromCharCode(...new TextEncoder().encode(s)));
+
+describe("parseOsc52", () => {
+  it("decodes a plain copy to the clipboard selection", () => {
+    expect(parseOsc52("c;aGVsbG8sIHdvcmxk")).toBe("hello, world");
+  });
+
+  it("decodes multi-byte UTF-8", () => {
+    expect(parseOsc52(`c;${b64("привет ⌘")}`)).toBe("привет ⌘");
+  });
+
+  it("accepts an empty selection field (defaults to clipboard)", () => {
+    expect(parseOsc52(";aGk=")).toBe("hi");
+  });
+
+  it("accepts multiple selection targets", () => {
+    expect(parseOsc52(`cs;${b64("hi")}`)).toBe("hi");
+  });
+
+  it("tolerates whitespace inside the base64 (chunked senders)", () => {
+    expect(parseOsc52("c;aGVs\nbG8=")).toBe("hello");
+  });
+
+  it("refuses the clipboard-read query", () => {
+    expect(parseOsc52("c;?")).toBeNull();
+  });
+
+  it("ignores an empty payload rather than clearing the clipboard", () => {
+    expect(parseOsc52("c;")).toBeNull();
+  });
+
+  it("ignores invalid base64", () => {
+    expect(parseOsc52("c;!!!not-base64!!!")).toBeNull();
+  });
+
+  it("ignores a payload with no selection separator", () => {
+    expect(parseOsc52("aGk=")).toBeNull();
+  });
+
+  it("ignores an oversized payload", () => {
+    const big = "A".repeat(OSC52_MAX_B64 + 4);
+    expect(parseOsc52(`c;${big}`)).toBeNull();
+  });
+});

--- a/client/src/views/terminal/osc52.test.ts
+++ b/client/src/views/terminal/osc52.test.ts
@@ -6,7 +6,7 @@
 // accept/reject line is worth pinning.
 
 import { describe, expect, it } from "vitest";
-import { parseOsc52, OSC52_MAX_B64 } from "./osc52";
+import { parseOsc52 } from "./osc52";
 
 const b64 = (s: string): string => btoa(String.fromCharCode(...new TextEncoder().encode(s)));
 
@@ -47,8 +47,12 @@ describe("parseOsc52", () => {
     expect(parseOsc52("aGk=")).toBeNull();
   });
 
-  it("ignores an oversized payload", () => {
-    const big = "A".repeat(OSC52_MAX_B64 + 4);
-    expect(parseOsc52(`c;${big}`)).toBeNull();
+  it("decodes a multi-megabyte payload (xterm's parser is the only ceiling)", () => {
+    // 8 MiB of base64 → 6 MiB of text. Payloads this size survive xterm's
+    // 10 MB OSC PAYLOAD_LIMIT, so they must reach the clipboard — a size cap
+    // here would silently drop a copy the multiplexer already reported done.
+    const out = parseOsc52(`c;${"YWFh".repeat(2 * 1024 * 1024)}`);
+    expect(out?.length).toBe(6 * 1024 * 1024);
+    expect(out?.[0]).toBe("a");
   });
 });

--- a/client/src/views/terminal/osc52.ts
+++ b/client/src/views/terminal/osc52.ts
@@ -4,17 +4,19 @@
 // answer it. Anything malformed is ignored rather than clearing or clobbering
 // whatever the user has in the clipboard.
 
-/** Longest base64 payload we accept — ~5 MiB decoded. tmux caps its own OSC 52
- *  writes far below this; anything bigger is not a human copying text. */
-export const OSC52_MAX_B64 = 7 * 1024 * 1024;
+// No size cap of our own: xterm's parser already aborts OSC payloads over
+// 10 MB (PAYLOAD_LIMIT) before they reach any handler, clipboard clobbering
+// is size-independent, and a cap here would silently drop a copy the
+// multiplexer already reported as done — the exact lie this module exists
+// to kill.
 
 /** `Pc;Pd` → the decoded text to put in the system clipboard, or null when the
- *  sequence should be ignored (query, empty, malformed, oversized). */
+ *  sequence should be ignored (query, empty, malformed). */
 export function parseOsc52(data: string): string | null {
   const sep = data.indexOf(";");
   if (sep < 0) return null;
   const payload = data.slice(sep + 1).replace(/\s+/g, "");
-  if (!payload || payload === "?" || payload.length > OSC52_MAX_B64) return null;
+  if (!payload || payload === "?") return null;
   let bin: string;
   try {
     bin = atob(payload);

--- a/client/src/views/terminal/osc52.ts
+++ b/client/src/views/terminal/osc52.ts
@@ -1,0 +1,26 @@
+// OSC 52 clipboard writes from the remote side (zellij, tmux `set-clipboard`,
+// nvim's clipboard provider). Write-only on purpose: the "?" form is the remote
+// host asking to READ the clipboard, which is an exfiltration channel — we never
+// answer it. Anything malformed is ignored rather than clearing or clobbering
+// whatever the user has in the clipboard.
+
+/** Longest base64 payload we accept — ~5 MiB decoded. tmux caps its own OSC 52
+ *  writes far below this; anything bigger is not a human copying text. */
+export const OSC52_MAX_B64 = 7 * 1024 * 1024;
+
+/** `Pc;Pd` → the decoded text to put in the system clipboard, or null when the
+ *  sequence should be ignored (query, empty, malformed, oversized). */
+export function parseOsc52(data: string): string | null {
+  const sep = data.indexOf(";");
+  if (sep < 0) return null;
+  const payload = data.slice(sep + 1).replace(/\s+/g, "");
+  if (!payload || payload === "?" || payload.length > OSC52_MAX_B64) return null;
+  let bin: string;
+  try {
+    bin = atob(payload);
+  } catch {
+    return null;
+  }
+  const bytes = Uint8Array.from(bin, (ch) => ch.charCodeAt(0));
+  return new TextDecoder().decode(bytes);
+}


### PR DESCRIPTION
## Summary

Two halves of the same promise: what you copy in the terminal actually reaches
the system clipboard, and what's in the clipboard actually has a key to paste it.

**OSC 52** — a multiplexer or editor on the remote side (zellij, tmux with
`set-clipboard on`, nvim) copies by asking the terminal to write its selection
into the system clipboard. We silently dropped that sequence, so zellij's
"text copied to system clipboard" was a lie, and copying under mouse reporting
meant fighting Option/Shift for a local selection. A new `osc52.ts` parses the
payload and hands it to the same native clipboard write every other copy path
uses — all platforms, mobile included. Write-only on purpose: the `?` form is
the remote host asking to **read** the clipboard, which is an exfiltration
channel, and it never gets an answer. Malformed payloads are ignored rather
than clobbering what the user already copied. No size cap of our own — xterm's
parser already aborts OSC payloads over 10 MB before any handler runs, and a
second cap here would only re-create the silent drop this exists to kill.

**Keyboard paste** — there was no explicit paste hotkey at all; macOS survived
on the webview's native ⌘V and Linux on native Ctrl+Shift+V, but WebView2 never
delivers a native paste to the xterm textarea, so Windows had no keyboard paste
whatsoever. Now Ctrl+V and Ctrl+Shift+V both paste on Linux/Windows (keydown
only — xterm runs the handler on keyup too, and without the guard every paste
would double). macOS is left on its native path, where a second handler would
be the double-paste.

Fixes #29.

## Testing

- 10 unit tests on the OSC 52 parser (UTF-8, query refusal, malformed base64,
  empty payload, multi-megabyte payload), written red-first; vitest 331/331.
- `tsc --noEmit` and `eslint .` clean — the same checks frontend CI runs.
- Runtime smoke still wanted on a real box: select in zellij with the mouse,
  paste elsewhere; Ctrl+V in bash on Windows.