### PR TITLE
fix(terminal): reset stale app modes when a pane reconnects

### DIFF
--- a/client/src/views/ViewTerminal.tsx
+++ b/client/src/views/ViewTerminal.tsx
@@ -28,6 +28,7 @@ import { splitLocalTerminal, useCtx } from "@/store/ctx";
 import { localRecordingRequest, useLocalMachine } from "@/store/localShell";
 import { createPaneEvents, type PaneEvents } from "@/views/terminal/paneSession";
 import { parseOsc52 } from "@/views/terminal/osc52";
+import { resetStaleAppModes } from "@/views/terminal/staleModes";
 import * as api from "@/bridge/api";
 import { apiErrorMessage, isApiError, type ConnectionProfile } from "@/bridge/types";
 import { writeText, readText } from "@tauri-apps/plugin-clipboard-manager";
@@ -742,6 +743,11 @@ async function runStartupSnippets(
       autoTimerRef.current = null;
     }
     if (pane.gen > 0) {
+      // The dead session's app may have left bracketed paste, mouse tracking,
+      // the alt screen etc. switched on in this reused xterm; the fresh shell
+      // starts from defaults, and the mismatch garbles pastes (#30) and eats
+      // clicks. Reset the app-owned modes without touching the scrollback.
+      void resetStaleAppModes(term);
       term.writeln("");
       const again = target.kind === "local" ? "terminal.restarting" : "terminal.reconnecting";
       term.writeln(`\x1b[2m— ${t(again)} —\x1b[0m`);

--- a/client/src/views/terminal/staleModes.test.ts
+++ b/client/src/views/terminal/staleModes.test.ts
@@ -1,0 +1,52 @@
+// A pane keeps its xterm instance across reconnects so scrollback survives —
+// but the dead session's app may have left private DEC modes switched on
+// (bracketed paste, mouse reporting, alt screen, …), and the fresh shell that
+// replaces it never asked for any of them. Issue #30 is the visible symptom:
+// xterm still believes bracketed paste is on, wraps every paste in ^[[200~,
+// and a server whose readline never enabled the mode prints the marker as
+// text. These tests drive a real (headless) Terminal, not a fake — the whole
+// point is what xterm's own mode tracking does.
+
+import { describe, expect, it } from "vitest";
+import { Terminal } from "@xterm/xterm";
+import { resetStaleAppModes } from "./staleModes";
+
+const write = (term: Terminal, data: string): Promise<void> =>
+  new Promise((r) => term.write(data, r));
+
+/** What a session that died inside a TUI leaves behind. */
+const MESS =
+  "\x1b[?2004h" + // bracketed paste
+  "\x1b[?1002h\x1b[?1006h" + // mouse drag tracking, SGR encoding
+  "\x1b[?1h" + // application cursor keys
+  "\x1b[?2026h" + // synchronized output (stale = output looks frozen)
+  "\x1b[?25l" + // cursor hidden
+  "\x1b[31m"; // dangling SGR
+
+describe("resetStaleAppModes", () => {
+  it("returns every app-owned mode to its default", async () => {
+    const term = new Terminal({ allowProposedApi: true });
+    await write(term, MESS + "\x1b[?1049h");
+    expect(term.modes.bracketedPasteMode).toBe(true);
+    expect(term.buffer.active.type).toBe("alternate");
+
+    await resetStaleAppModes(term);
+
+    expect(term.modes.bracketedPasteMode).toBe(false);
+    expect(term.modes.mouseTrackingMode).toBe("none");
+    expect(term.modes.applicationCursorKeysMode).toBe(false);
+    expect(term.modes.synchronizedOutputMode).toBe(false);
+    expect(term.buffer.active.type).toBe("normal");
+  });
+
+  it("leaves screen content and cursor alone — this is not term.reset()", async () => {
+    const term = new Terminal({ allowProposedApi: true });
+    await write(term, "abc" + MESS);
+
+    await resetStaleAppModes(term);
+
+    expect(term.buffer.active.getLine(0)?.translateToString(true)).toBe("abc");
+    expect(term.buffer.active.cursorX).toBe(3);
+    expect(term.buffer.active.type).toBe("normal");
+  });
+});

--- a/client/src/views/terminal/staleModes.ts
+++ b/client/src/views/terminal/staleModes.ts
@@ -1,0 +1,30 @@
+// Clearing what a dead session's app left switched on. A pane deliberately
+// keeps its xterm across reconnects (scrollback survives), so the terminal-side
+// half of every private DEC mode survives too — but the fresh shell on the
+// other end starts from defaults and never asked for any of it. The mismatch
+// is user-visible: stale bracketed paste wraps pastes in ^[[200~ that an old
+// readline prints as text (issue #30), stale mouse tracking eats clicks, a
+// stale alt screen hides the scrollback, stale synchronized output looks like
+// a hang. term.reset() would fix all of that by destroying the scrollback we
+// kept the terminal for; instead, write the DECRST for each app-owned mode —
+// exactly what a well-behaved app would have sent on exit.
+
+import type { Terminal } from "@xterm/xterm";
+
+/** Resolves once xterm has processed the resets (term.write is async). */
+export function resetStaleAppModes(term: Terminal): Promise<void> {
+  // Leave the alternate screen first, and only when actually in it: DECRST 1049
+  // also restores a saved cursor, which on the normal buffer would move the
+  // cursor for no reason.
+  const seq =
+    (term.buffer.active.type === "alternate" ? "\x1b[?1049l" : "") +
+    "\x1b[?2004l" + // bracketed paste
+    "\x1b[?9l\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l" + // mouse tracking + its SGR encoding
+    "\x1b[?1l" + // application cursor keys
+    "\x1b[?1004l" + // focus reporting
+    "\x1b[?2026l" + // synchronized output
+    "\x1b[4l" + // insert mode
+    "\x1b[?25h" + // cursor visible again
+    "\x1b[0m"; // dangling SGR attributes
+  return new Promise((resolve) => term.write(seq, () => resolve()));
+}


### PR DESCRIPTION
## Summary

The most plausible client-side root of #30 (`^[[200~` printed on paste, Windows
reporter, not reproducible on someone else's Linux setup — i.e. environment-, not
OS-shaped).

A pane keeps its xterm instance across reconnects on purpose: the scrollback is
the reason. But that means the terminal-side half of every private DEC mode
survives the reconnect too, while the fresh shell on the other end starts from
defaults and never asked for any of it. Die inside vim/zellij, auto-reconnect,
and xterm still believes bracketed paste is on — every paste gets wrapped in
`ESC[200~ … ESC[201~`, and a server whose readline never enabled the mode (old
bash, CentOS-vintage readline) prints the marker as literal text. Same story,
different symptoms, for the neighbours: stale mouse tracking eats clicks, a
stale alt screen hides the scrollback, stale synchronized output looks like a
freeze, a hidden cursor stays hidden.

`term.reset()` would cure all of it by destroying the scrollback we kept the
terminal for. Instead `resetStaleAppModes` writes the DECRST for each app-owned
mode — exactly what a well-behaved app would have sent on exit — and the
reconnect path calls it before the "— reconnecting —" banner. The alt-screen
leave is conditional on actually being in the alt buffer, because DECRST 1049
also restores a saved cursor and would move it on the normal buffer for no
reason.

Tests drive a real headless `Terminal` and pin three things: every mode returns
to default, the alt screen is left, and screen content + cursor stay untouched
(this is not a reset).

Not marked as closing #30: the same symptom can also come from the remote side's
own lifecycle (an app that died without cleaning up, which no terminal can
prevent) — the reporter should confirm on a build with this fix.

## Testing

- 2 new tests against a real headless xterm (vitest 323/323).
- `tsc --noEmit`, `eslint .` clean.
- Runtime check that matters: connect, open vim or zellij, kill the connection,
  let the pane auto-reconnect, paste — no `^[[200~`, mouse selection works.