### PR TITLE
docs(deploy): deployment scenarios — own certs, proxy in front (nginx/Traefik/CDN), LAN internal CA

### DIFF
--- a/client/src-tauri/src/cloud/client.rs
+++ b/client/src-tauri/src/cloud/client.rs
@@ -221,10 +221,59 @@ fn retry_after_secs(resp: &Response) -> u64 {
 }
 
 fn transport_err(e: reqwest::Error) -> ApiError {
+    let mut message = e.to_string();
+    if let Some(hint) = tls_hint(&error_chain(&e)) {
+        message.push_str(" — ");
+        message.push_str(hint);
+    }
     ApiError::Server {
         code: "network".into(),
-        message: e.to_string(),
+        message,
     }
+}
+
+/// Flatten an error and its `source()` chain into one lowercase haystack. The
+/// outer Display of a failed request is only "error sending request for url
+/// (...)"; the reason (rustls' certificate verdict) lives several sources down.
+fn error_chain(e: &dyn std::error::Error) -> String {
+    use std::fmt::Write;
+    let mut out = String::new();
+    let mut cur = Some(e);
+    while let Some(err) = cur {
+        let _ = write!(out, "{err}; ");
+        cur = err.source();
+    }
+    out.to_ascii_lowercase()
+}
+
+/// Turn a TLS verification failure into an instruction. Self-hosting behind a
+/// private CA is a supported deployment, and it is the one case where the raw
+/// message ("invalid peer certificate: unknownissuer") names the symptom and
+/// nothing else — the operator has to already know that the fix is a trust-store
+/// install. The client verifies against the OS trust store (rustls
+/// platform-verifier), so that is where the CA root has to go.
+fn tls_hint(chain: &str) -> Option<&'static str> {
+    if !chain.contains("certificate") {
+        return None;
+    }
+    if chain.contains("unknownissuer") || chain.contains("unknown issuer") {
+        return Some(
+            "the server's TLS certificate is not trusted by this machine. \
+             If it is self-signed or issued by an internal CA (e.g. Caddy's \
+             \"tls internal\"), install that CA's root certificate into this \
+             machine's system trust store: https://unissh.dev/operations/deploy-scenarios/",
+        );
+    }
+    if chain.contains("notvalidforname") {
+        return Some(
+            "the server's TLS certificate is not valid for this hostname — \
+             use the exact hostname the certificate was issued for",
+        );
+    }
+    if chain.contains("expired") {
+        return Some("the server's TLS certificate has expired (or this machine's clock is wrong)");
+    }
+    None
 }
 
 /// Map `{error:{code,message,retry_after}}` → `ApiError::Server`. Falls back to the
@@ -295,6 +344,36 @@ mod base_url_tests {
         assert!(validate_base_url("ftp://cloud.example.com").is_err());
         assert!(validate_base_url("cloud.example.com").is_err());
         assert!(validate_base_url("https://").is_err());
+    }
+}
+
+#[cfg(test)]
+mod tls_hint_tests {
+    use super::tls_hint;
+
+    /// The strings are what rustls actually produces, lowercased by
+    /// `error_chain`: a private-CA server is the case the hint exists for.
+    #[test]
+    fn untrusted_issuer_gets_the_trust_store_instruction() {
+        let chain = "error sending request for url (https://unissh.local/v1/health); \
+                     invalid peer certificate: unknownissuer; ";
+        assert!(tls_hint(chain).unwrap().contains("system trust store"));
+    }
+
+    #[test]
+    fn hostname_mismatch_and_expiry_are_distinguished() {
+        assert!(tls_hint("invalid peer certificate: notvalidforname; ")
+            .unwrap()
+            .contains("hostname"));
+        assert!(tls_hint("invalid peer certificate: expired; ")
+            .unwrap()
+            .contains("expired"));
+    }
+
+    #[test]
+    fn ordinary_transport_failures_get_no_hint() {
+        assert!(tls_hint("error sending request; connection refused; ").is_none());
+        assert!(tls_hint("operation timed out; ").is_none());
     }
 }
 

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -91,6 +91,10 @@ services:
       UNISSH__SERVER__TLS_CERT: ""
       UNISSH__SERVER__TLS_KEY: ""
       UNISSH__SERVER__TRUST_PROXY: "true"
+      # External base URL, used to render invite links ({public_url}/join#…).
+      # Empty => invites come back without a ready-made URL. Set it in .env
+      # to the address users actually type, including a non-standard port.
+      UNISSH__SERVER__PUBLIC_URL: "${UNISSH__SERVER__PUBLIC_URL:-}"
       # acme left unset/false on purpose: acme=true is a hard startup error.
       # --- Database (SQLite default; Postgres via the `postgres` profile + .env override) ---
       UNISSH__DB__BACKEND: "${UNISSH__DB__BACKEND:-sqlite}"

--- a/compose.yml
+++ b/compose.yml
@@ -85,6 +85,10 @@ services:
       UNISSH__SERVER__TLS_CERT: ""
       UNISSH__SERVER__TLS_KEY: ""
       UNISSH__SERVER__TRUST_PROXY: "true"
+      # External base URL, used to render invite links ({public_url}/join#…).
+      # Empty => invites come back without a ready-made URL. Set it in .env
+      # to the address users actually type, including a non-standard port.
+      UNISSH__SERVER__PUBLIC_URL: "${UNISSH__SERVER__PUBLIC_URL:-}"
       # acme left unset/false on purpose: acme=true is a hard startup error.
       # --- Database (SQLite default; Postgres via the `postgres` profile + .env override) ---
       UNISSH__DB__BACKEND: "${UNISSH__DB__BACKEND:-sqlite}"

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -31,6 +31,13 @@ UNISSH_DOMAIN=unissh.example.com
 #                                -f deploy/compose.tls-files.yml up -d
 UNISSH_TLS_DIRECTIVE=tls admin@example.com
 
+# Only used by deploy/compose.traefik.yml (publishing through a Traefik you
+# already run): the Docker network your traefik container is on, the hostname to
+# route, and the certresolver it should use.
+# TRAEFIK_NETWORK=traefik
+# UNISSH_HOST=unissh.example.com
+# UNISSH_CERTRESOLVER=letsencrypt
+
 # Only used by deploy/compose.tls-files.yml: the host directory holding
 # fullchain.pem + privkey.pem, mounted read-only at /certs. Relative paths
 # resolve against the repo root (where compose.yml lives).

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -22,7 +22,24 @@ UNISSH_DOMAIN=unissh.example.com
 #   "tls you@example.com"   -> automatic public ACME with an account email
 #                              (recommended for prod — enables expiry notices).
 #   "tls internal"          -> Caddy internal CA / self-signed (LAN / air-gapped).
+#                              Every client machine must then trust that CA root:
+#                              https://unissh.dev/operations/deploy-scenarios/
+#   "tls /certs/fullchain.pem /certs/privkey.pem"
+#                           -> certificate files you already have. Mount them
+#                              with the deploy/compose.tls-files.yml override:
+#                              docker compose -f compose.prod.yml \
+#                                -f deploy/compose.tls-files.yml up -d
 UNISSH_TLS_DIRECTIVE=tls admin@example.com
+
+# Only used by deploy/compose.tls-files.yml: the host directory holding
+# fullchain.pem + privkey.pem, mounted read-only at /certs. Relative paths
+# resolve against the repo root (where compose.yml lives).
+# UNISSH_CERTS_DIR=./certs
+
+# OPTIONAL — external base URL used to render invite links
+# ({public_url}/join#<token>). Leave unset and invites come back without a URL.
+# Include the port if you don't serve on 443.
+# UNISSH__SERVER__PUBLIC_URL=https://unissh.example.com
 
 # -----------------------------------------------------------------------------
 # First-run setup  (no token required)

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -11,6 +11,9 @@
 #       ""                      automatic public ACME, no account email (default)
 #       "tls you@example.com"   automatic public ACME with an account email
 #       "tls internal"          Caddy internal CA / self-signed (LAN, air-gapped)
+#       "tls /certs/fullchain.pem /certs/privkey.pem"
+#                               certificate files you already have (mount them
+#                               with deploy/compose.tls-files.yml)
 #
 # TLS modes:
 #   ACME: Caddy obtains a public cert automatically (Let's Encrypt / ZeroSSL via
@@ -18,8 +21,17 @@
 #         HTTP->HTTPS redirect; 443 serves the app. Supplying an email via
 #         "tls you@example.com" enables expiry notices.
 #   internal ("tls internal"): Caddy issues a cert from its own internal CA
-#         (self-signed). Trust Caddy's root on clients, or accept the cert. Use
-#         for LAN hosts (*.local) or IPs with no public DNS.
+#         (self-signed). Use for LAN hosts (*.local) or IPs with no public DNS.
+#         Every client machine must then TRUST that CA root — the desktop client
+#         verifies against the OS trust store and has no "accept anyway" prompt,
+#         and it refuses plain http:// to a non-loopback host. Export the root
+#         from the caddy-data volume (/data/caddy/pki/authorities/local/root.crt)
+#         and install it. The "certutil is not available" line in Caddy's log is
+#         only about trusting the root INSIDE this container — it is unrelated,
+#         and installing certutil there fixes nothing for clients.
+#   files ("tls <cert> <key>"): certificates you already hold (internal CA,
+#         commercial wildcard, DNS-01, certbot on the host). Caddy reloads them
+#         in place on renewal.
 # This single placeholder covers every mode with no image rebuild.
 # =============================================================================
 {$UNISSH_DOMAIN} {

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -30,8 +30,10 @@
 #         only about trusting the root INSIDE this container — it is unrelated,
 #         and installing certutil there fixes nothing for clients.
 #   files ("tls <cert> <key>"): certificates you already hold (internal CA,
-#         commercial wildcard, DNS-01, certbot on the host). Caddy reloads them
-#         in place on renewal.
+#         commercial wildcard, DNS-01, certbot on the host). These are loaded
+#         ONCE — after a renewal, rewriting the files is not enough; reload with
+#         `caddy reload --force` or restart the container (see
+#         deploy/compose.tls-files.yml).
 # This single placeholder covers every mode with no image rebuild.
 # =============================================================================
 {$UNISSH_DOMAIN} {

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -26,9 +26,9 @@
 #         verifies against the OS trust store and has no "accept anyway" prompt,
 #         and it refuses plain http:// to a non-loopback host. Export the root
 #         from the caddy-data volume (/data/caddy/pki/authorities/local/root.crt)
-#         and install it. The "certutil is not available" line in Caddy's log is
-#         only about trusting the root INSIDE this container — it is unrelated,
-#         and installing certutil there fixes nothing for clients.
+#         and install it. (The "certutil is not available" line older images
+#         logged was about trusting the root INSIDE this container — unrelated
+#         to clients; see skip_install_trust in the global block below.)
 #   files ("tls <cert> <key>"): certificates you already hold (internal CA,
 #         commercial wildcard, DNS-01, certbot on the host). These are loaded
 #         ONCE — after a renewal, rewriting the files is not enough; reload with
@@ -36,6 +36,20 @@
 #         deploy/compose.tls-files.yml).
 # This single placeholder covers every mode with no image rebuild.
 # =============================================================================
+{
+	# Don't try to install the internal CA root into THIS CONTAINER's trust
+	# store. Nothing in the container consumes it — the root has to be trusted
+	# on the machines running the client — so the attempt only ever produced a
+	# scary-looking log line that sent operators chasing the wrong thing:
+	#   warning: "certutil" is not available, install "certutil" with
+	#   "apt install libnss3-tools" or "yum install nss-tools" and try again
+	# Skipping it changes nothing else: the CA is still created, certificates
+	# are still issued, and the root is still exportable from the caddy-data
+	# volume at /data/caddy/pki/authorities/local/root.crt. No-op for the ACME
+	# and file-certificate modes, which never install anything locally.
+	skip_install_trust
+}
+
 {$UNISSH_DOMAIN} {
 	# --- TLS mode (see header) — empty in ACME-without-email mode. ---
 	{$UNISSH_TLS_DIRECTIVE}

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -75,7 +75,9 @@ TLS is controlled by a single env knob, `UNISSH_TLS_DIRECTIVE`:
   `UNISSH_TLS_DIRECTIVE="tls /certs/fullchain.pem /certs/privkey.pem"` and mount
   the directory with the `compose.tls-files.yml` override in this folder:
   `docker compose -f compose.prod.yml -f deploy/compose.tls-files.yml up -d`.
-  Caddy reloads the files in place when they are renewed.
+  Renewal is NOT picked up on its own — after replacing the files run
+  `docker compose exec caddy caddy reload --force --config /etc/caddy/Caddyfile`
+  (or `docker compose restart caddy`).
 - **LAN / air-gapped (self-signed internal CA):** set `UNISSH_DOMAIN` to a local
   host (e.g. `unissh.local`) or an IP and set `UNISSH_TLS_DIRECTIVE="tls internal"`
   in `.env`. Caddy issues a cert from its own internal CA — and every client

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -91,10 +91,19 @@ The `caddy-data` volume persists issued certs / the internal CA root — keep it
 ## Other front doors
 
 - `compose.tls-files.yml` — Caddy, but with certificate files you supply.
-- `compose.reverse-proxy.yml` — no bundled Caddy; publishes the API on
-  `127.0.0.1:8443` for your own nginx/HAProxy/Traefik.
-- `nginx/unissh.conf` — a complete nginx server block (TLS + SPA + API proxy)
-  equivalent to the Caddyfile.
+- `compose.behind-proxy.yml` — Caddy stays as a PLAIN-HTTP front on
+  `127.0.0.1:8080` (SPA + API), for a proxy you already run to terminate TLS in
+  front of. Recommended: the panel keeps travelling with the image, so upgrades
+  need no file syncing.
+- `compose.traefik.yml` — the same, published through an existing Traefik by
+  labels over a shared Docker network; nothing host-published.
+- `compose.reverse-proxy.yml` — no bundled Caddy at all; publishes the API on
+  `127.0.0.1:8443` for a proxy that will also serve the SPA itself.
+- `nginx/unissh.conf` — TLS + one proxy_pass to the stack (pairs with
+  compose.behind-proxy.yml).
+- `nginx/unissh-static-spa.conf` — nginx doing the Caddyfile's whole job: TLS,
+  the SPA from disk, the API proxied straight to the server (pairs with
+  compose.reverse-proxy.yml). One hop, so the server sees real client IPs.
 
 Full write-up, including client-side CA trust and a no-proxy variant:
 <https://unissh.dev/operations/deploy-scenarios/>.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -85,8 +85,9 @@ TLS is controlled by a single env knob, `UNISSH_TLS_DIRECTIVE`:
   `/data/caddy/pki/authorities/local/root.crt` and install it in the OS trust
   store). The client verifies against the OS store, has no "accept anyway"
   prompt, and refuses plain `http://` to a non-loopback host. The
-  `"certutil" is not available` line in Caddy's log is about trusting the root
-  *inside the container* and is unrelated.
+  `"certutil" is not available` line older images logged was about trusting the
+  root *inside the container* — unrelated to clients, and suppressed now via
+  `skip_install_trust` in the Caddyfile.
 
 The `caddy-data` volume persists issued certs / the internal CA root — keep it.
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -71,13 +71,33 @@ TLS is controlled by a single env knob, `UNISSH_TLS_DIRECTIVE`:
   leave it empty for ACME without an account email). Caddy gets a public cert
   (Let's Encrypt / ZeroSSL via HTTP-01 or TLS-ALPN-01). Port 80 must be reachable
   for the challenge + HTTP→HTTPS redirect.
+- **Certificates you already have:** set
+  `UNISSH_TLS_DIRECTIVE="tls /certs/fullchain.pem /certs/privkey.pem"` and mount
+  the directory with the `compose.tls-files.yml` override in this folder:
+  `docker compose -f compose.prod.yml -f deploy/compose.tls-files.yml up -d`.
+  Caddy reloads the files in place when they are renewed.
 - **LAN / air-gapped (self-signed internal CA):** set `UNISSH_DOMAIN` to a local
   host (e.g. `unissh.local`) or an IP and set `UNISSH_TLS_DIRECTIVE="tls internal"`
-  in `.env`. Caddy issues a cert from its own internal CA. Trust Caddy's root CA
-  on clients (export it from the `caddy-data` volume at
-  `/data/caddy/pki/authorities/local/root.crt`) or accept the self-signed cert.
+  in `.env`. Caddy issues a cert from its own internal CA — and every client
+  machine must then TRUST that root (export it from the `caddy-data` volume at
+  `/data/caddy/pki/authorities/local/root.crt` and install it in the OS trust
+  store). The client verifies against the OS store, has no "accept anyway"
+  prompt, and refuses plain `http://` to a non-loopback host. The
+  `"certutil" is not available` line in Caddy's log is about trusting the root
+  *inside the container* and is unrelated.
 
 The `caddy-data` volume persists issued certs / the internal CA root — keep it.
+
+## Other front doors
+
+- `compose.tls-files.yml` — Caddy, but with certificate files you supply.
+- `compose.reverse-proxy.yml` — no bundled Caddy; publishes the API on
+  `127.0.0.1:8443` for your own nginx/HAProxy/Traefik.
+- `nginx/unissh.conf` — a complete nginx server block (TLS + SPA + API proxy)
+  equivalent to the Caddyfile.
+
+Full write-up, including client-side CA trust and a no-proxy variant:
+<https://unissh.dev/operations/deploy-scenarios/>.
 
 ## Content Security Policy / wasm
 

--- a/deploy/compose.behind-proxy.yml
+++ b/deploy/compose.behind-proxy.yml
@@ -1,0 +1,45 @@
+# =============================================================================
+# UniSSH — compose OVERRIDE: put the whole stack behind a proxy you already run
+# (nginx, Traefik, HAProxy, a Cloudflare tunnel, an appliance…).
+#
+# The bundled Caddy STAYS — it just stops doing TLS and stops taking 80/443.
+# Setting its site address to ":80" makes it a plain-HTTP front on loopback:
+# still serving the admin SPA, still proxying /v1 /healthz /readyz to the
+# server. Your proxy terminates TLS and forwards everything to it:
+#
+#   client ──TLS──► your proxy ──HTTP──► 127.0.0.1:8080 (caddy) ──► server:8443
+#
+#   docker compose -f compose.prod.yml -f deploy/compose.behind-proxy.yml up -d
+#   curl -i http://127.0.0.1:8080/          # SPA
+#   curl -i http://127.0.0.1:8080/readyz    # proxied to the server
+#
+# Prefer this over serving the SPA from your proxy's own docroot: the panel is
+# versioned with the server, so a docroot copy has to be re-synced on every
+# upgrade and silently skews if it isn't. Here `docker compose pull && up -d`
+# upgrades both at once. Forward ALL paths to it, not just /v1 — it is the
+# origin for the SPA too, and same-origin is what keeps CORS off.
+#
+# Keep UNISSH_DOMAIN set to your REAL public hostname in .env (compose still
+# interpolates it, and UNISSH__SERVER__PUBLIC_URL should match what users type).
+# The override below is what actually decides Caddy's listener.
+#
+# `!override` replaces the base file's published ports instead of appending to
+# them — a plain list would leave 80/443 mapped as well. It needs Compose
+# v2.24+; on an older one, use deploy/compose.reverse-proxy.yml instead.
+#
+# If your proxy runs in Docker too, drop the ports block below, attach the proxy
+# to the `unissh` network, and forward to http://caddy:80 by service name —
+# then nothing is host-published at all.
+# =============================================================================
+
+name: unissh
+
+services:
+  caddy:
+    environment:
+      # ":80" = listen on port 80, plain HTTP, no ACME, no internal CA. The
+      # public hostname is your proxy's business now.
+      UNISSH_DOMAIN: ":80"
+      UNISSH_TLS_DIRECTIVE: ""
+    ports: !override
+      - "127.0.0.1:8080:80"

--- a/deploy/compose.reverse-proxy.yml
+++ b/deploy/compose.reverse-proxy.yml
@@ -1,0 +1,45 @@
+# =============================================================================
+# UniSSH — compose OVERRIDE: bring your OWN reverse proxy (nginx, HAProxy,
+# Traefik, an appliance…) instead of the bundled Caddy.
+#
+# It does two things:
+#   * parks the `caddy` service behind a profile that is never enabled, so
+#     `up -d` no longer starts it and ports 80/443 stay free for your proxy;
+#   * publishes the server's API on 127.0.0.1:8443 — LOOPBACK ONLY, plain HTTP,
+#     for the proxy on the same host to forward to. It is NOT reachable off-box.
+#
+#   docker compose -f compose.prod.yml -f deploy/compose.reverse-proxy.yml up -d
+#   curl http://127.0.0.1:8443/readyz
+#
+# Your proxy MUST terminate TLS: the client refuses a plaintext http:// server
+# URL to anything but loopback, because the bearer tokens ride that connection.
+# A ready-made nginx server block is in deploy/nginx/unissh.conf.
+#
+# The admin SPA is inside the caddy image, which is no longer running — serve
+# its files from your proxy instead (extract them once with `docker create` +
+# `docker cp`; see deploy/nginx/unissh.conf and
+# https://unissh.dev/operations/deploy-scenarios/). Serving the SPA from the
+# SAME origin as /v1 is what keeps CORS off.
+#
+# If the proxy runs in Docker rather than on the host, drop the `ports:` block
+# below, attach that container to the `unissh` network, and forward to
+# http://server:8443 by service name — then nothing is host-published at all.
+#
+# trust_proxy stays true (set in the base file): the server reads the RIGHTMOST
+# X-Forwarded-For element as the client IP for rate limiting, so the proxy must
+# append the real peer — and must not let a client-supplied value through as the
+# last hop.
+# =============================================================================
+
+name: unissh
+
+services:
+  caddy:
+    # A profile nobody enables = a service compose never starts. (Overrides can
+    # add to a service but cannot delete one, so this is how a bundled service
+    # gets switched off.)
+    profiles: ["bundled-caddy"]
+
+  server:
+    ports:
+      - "127.0.0.1:8443:8443"

--- a/deploy/compose.reverse-proxy.yml
+++ b/deploy/compose.reverse-proxy.yml
@@ -13,11 +13,11 @@
 #
 # Your proxy MUST terminate TLS: the client refuses a plaintext http:// server
 # URL to anything but loopback, because the bearer tokens ride that connection.
-# A ready-made nginx server block is in deploy/nginx/unissh.conf.
+# A ready-made nginx server block is in deploy/nginx/unissh-static-spa.conf.
 #
 # The admin SPA is inside the caddy image, which is no longer running — serve
 # its files from your proxy instead (extract them once with `docker create` +
-# `docker cp`; see deploy/nginx/unissh.conf and
+# `docker cp`; see deploy/nginx/unissh-static-spa.conf and
 # https://unissh.dev/operations/deploy-scenarios/). Serving the SPA from the
 # SAME origin as /v1 is what keeps CORS off.
 #

--- a/deploy/compose.tls-files.yml
+++ b/deploy/compose.tls-files.yml
@@ -21,9 +21,17 @@
 # Relative host paths resolve against the FIRST -f file's directory (the repo
 # root), not against deploy/ — hence ./certs, not ../certs.
 #
-# The mount is read-only. Caddy watches the files and picks up a renewed cert
-# without a restart, so a renewal on the host only has to rewrite these two
-# paths (`cp` the new files in place); no `docker compose` command is needed.
+# The mount is read-only.
+#
+# RENEWAL IS NOT AUTOMATIC. Caddy loads these files once and keeps serving the
+# certificate it loaded: rewriting them on disk changes nothing, and neither
+# does `caddy reload` (the config is unchanged, so it is a no-op). Verified by
+# swapping the files under a running container — the old cert was still served.
+# After a renewal you MUST do one of:
+#   docker compose exec caddy caddy reload --force --config /etc/caddy/Caddyfile
+#   docker compose restart caddy
+# Wire that into your certbot/acme.sh deploy hook, or the instance goes on
+# serving an expired certificate until someone notices.
 # =============================================================================
 
 name: unissh

--- a/deploy/compose.tls-files.yml
+++ b/deploy/compose.tls-files.yml
@@ -1,0 +1,36 @@
+# =============================================================================
+# UniSSH — compose OVERRIDE: serve TLS from certificate files you already have.
+#
+# Use this when the certificate does NOT come from ACME: a corporate/internal CA,
+# a wildcard bought from a commercial CA, a cert issued out-of-band by DNS-01, or
+# one managed on the host by certbot/acme.sh. Caddy stays the front door (it
+# still serves the SPA and proxies the API) — only the source of the cert
+# changes, so nothing about the topology or the server config moves.
+#
+#   1. Put the chain + key where this file expects them (repo root by default):
+#        ./certs/fullchain.pem     server cert + intermediates, leaf FIRST
+#        ./certs/privkey.pem       its private key (PKCS#8 or PKCS#1, unencrypted)
+#      Or point UNISSH_CERTS_DIR at any directory holding those two names.
+#   2. In .env:
+#        UNISSH_DOMAIN=unissh.example.com
+#        UNISSH_TLS_DIRECTIVE=tls /certs/fullchain.pem /certs/privkey.pem
+#   3. Start with BOTH files (the override must come second):
+#        docker compose -f compose.yml      -f deploy/compose.tls-files.yml up -d --build
+#        docker compose -f compose.prod.yml -f deploy/compose.tls-files.yml up -d
+#
+# Relative host paths resolve against the FIRST -f file's directory (the repo
+# root), not against deploy/ — hence ./certs, not ../certs.
+#
+# The mount is read-only. Caddy watches the files and picks up a renewed cert
+# without a restart, so a renewal on the host only has to rewrite these two
+# paths (`cp` the new files in place); no `docker compose` command is needed.
+# =============================================================================
+
+name: unissh
+
+services:
+  caddy:
+    volumes:
+      # Merged with the base file's caddy-data/caddy-config mounts (compose
+      # unions service volumes by container path).
+      - "${UNISSH_CERTS_DIR:-./certs}:/certs:ro"

--- a/deploy/compose.traefik.yml
+++ b/deploy/compose.traefik.yml
@@ -1,0 +1,61 @@
+# =============================================================================
+# UniSSH — compose OVERRIDE: publish through a Traefik you already run.
+#
+# Same idea as compose.behind-proxy.yml (the bundled Caddy stays, as a plain
+# HTTP front serving the SPA and proxying the API), except nothing is published
+# on the host at all: Traefik reaches Caddy over a shared Docker network and
+# terminates TLS with whatever resolver/certificate you already have.
+#
+#   client ──TLS──► traefik ──HTTP──► caddy:80 ──► server:8443
+#
+#   # .env: TRAEFIK_NETWORK=<the network your traefik container is on>
+#   #       UNISSH_HOST=unissh.example.com
+#   #       UNISSH_CERTRESOLVER=<your traefik certresolver name>
+#   docker compose -f compose.prod.yml -f deploy/compose.traefik.yml up -d
+#
+# The four labels below are the whole integration and were verified end to end
+# (SPA, deep links, API, and the stack's security headers all survive the hop).
+# Adjust the router/service name (`unissh`) if it collides with something.
+#
+# Traefik's `websecure` entrypoint and the certresolver are YOUR Traefik's
+# config, not this file's — if your entrypoint is named differently, change it
+# here. If Traefik already terminates TLS through Cloudflare or another
+# certresolver, drop the tls.certresolver label.
+#
+# Caveat, same as any two-hop layout: the server sees Caddy's peer (Traefik) as
+# the client address, so the per-IP rate limit applies instance-wide rather than
+# per client. Raise limits.rate_limit_per_ip_rps, or run the one-hop layout
+# (deploy/compose.reverse-proxy.yml + deploy/nginx/unissh-static-spa.conf).
+# =============================================================================
+
+name: unissh
+
+services:
+  caddy:
+    environment:
+      # Plain HTTP on :80, no ACME, no internal CA — TLS is Traefik's job.
+      UNISSH_DOMAIN: ":80"
+      UNISSH_TLS_DIRECTIVE: ""
+    # `!override` REPLACES the base file's 80/443 mappings (a plain list would
+    # append). Nothing is host-published: Traefik reaches Caddy over the network.
+    ports: !override []
+    networks:
+      - unissh
+      - traefik
+    labels:
+      traefik.enable: "true"
+      traefik.docker.network: "${TRAEFIK_NETWORK:?set TRAEFIK_NETWORK in .env}"
+      traefik.http.routers.unissh.rule: "Host(`${UNISSH_HOST:?set UNISSH_HOST in .env}`)"
+      traefik.http.routers.unissh.entrypoints: "websecure"
+      traefik.http.routers.unissh.tls: "true"
+      # DELETE this line if your Traefik gets its certificates some other way
+      # (a static cert store, a Cloudflare origin cert…) — an empty resolver
+      # name is not the same as no resolver.
+      traefik.http.routers.unissh.tls.certresolver: "${UNISSH_CERTRESOLVER:?set UNISSH_CERTRESOLVER in .env, or delete this label}"
+      # The port INSIDE the caddy container, not a host port.
+      traefik.http.services.unissh.loadbalancer.server.port: "80"
+
+networks:
+  traefik:
+    name: "${TRAEFIK_NETWORK:?set TRAEFIK_NETWORK in .env}"
+    external: true

--- a/deploy/nginx/unissh-static-spa.conf
+++ b/deploy/nginx/unissh-static-spa.conf
@@ -1,0 +1,150 @@
+# =============================================================================
+# UniSSH — nginx server block: nginx replaces the bundled Caddy entirely.
+#
+# The one-hop variant. nginx does the exact job deploy/Caddyfile does — terminate
+# TLS, serve the admin SPA from disk, reverse-proxy the API to the server — and
+# the bundled Caddy is not started at all.
+#
+# Pick this over the simpler unissh.conf when the server must see REAL client
+# addresses (per-IP rate limiting, access logs, fail2ban). The cost is that the
+# admin panel is a copy on your disk: it is versioned with the server, so it has
+# to be re-copied on every upgrade or it silently skews.
+#
+#   client ──TLS──► nginx ──plain HTTP──► 127.0.0.1:8443 (unissh-server)
+#                     └─ SPA from /var/www/unissh
+#
+# Install:
+#   1. Start the server WITHOUT the bundled Caddy — it publishes 127.0.0.1:8443:
+#        docker compose -f compose.prod.yml -f deploy/compose.reverse-proxy.yml up -d
+#   2. Put the admin SPA on disk (the files live in the caddy image at /srv):
+#        cid=$(docker create ghcr.io/goduni/unissh-caddy:latest)
+#        docker cp "$cid:/srv/." /var/www/unissh/
+#        docker rm "$cid"
+#      (Repeat after every upgrade — the SPA is versioned with the server.)
+#   3. Copy this file to /etc/nginx/sites-available/unissh.conf (or conf.d/),
+#      edit server_name + the two ssl_certificate paths, then:
+#        nginx -t && systemctl reload nginx
+#
+# The SPA and /v1 MUST stay on ONE origin: the panel calls the API with a
+# relative base, so same-origin is what keeps CORS disabled server-side. Do not
+# split them across two hostnames.
+# =============================================================================
+
+# Some distributions' mime.types predate WebAssembly. The panel's crypto module
+# is loaded with WebAssembly.instantiateStreaming, which REJECTS anything not
+# served as application/wasm — the panel would fail to unlock with a console
+# error and no other symptom. On an nginx whose mime.types already has it, this
+# is a no-op that logs one `duplicate extension "wasm"` warning at config test —
+# expected, and cheaper than the failure it prevents.
+types {
+    application/wasm wasm;
+}
+
+# Cache policy as a map rather than per-location `add_header`, because in nginx
+# an `add_header` inside a location DROPS every header inherited from the server
+# block — a per-location cache header would silently strip the CSP from exactly
+# the responses that need it. One header, set once, computed from the path:
+# hashed assets are immutable, everything else (the SPA shell, the API) is not.
+map $uri $unissh_cache_control {
+    default          "no-store";
+    ~^/assets/       "public, max-age=31536000, immutable";
+}
+
+# --- :80 — redirect only. ----------------------------------------------------
+# Keep it: it is also where an HTTP-01 ACME challenge is answered if you renew
+# with certbot/acme.sh on this host.
+server {
+    listen 80;
+    listen [::]:80;
+    server_name unissh.example.com;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/html;
+    }
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    http2 on;                       # nginx >= 1.25; older: `listen 443 ssl http2;`
+    server_name unissh.example.com;
+
+    # --- TLS: your existing certificate ---------------------------------------
+    # fullchain = leaf FIRST, then intermediates. Serving the leaf alone is the
+    # classic "works in my browser, fails in the client" bug: browsers often
+    # patch a missing intermediate from cache, non-browser clients never do.
+    ssl_certificate     /etc/ssl/unissh/fullchain.pem;
+    ssl_certificate_key /etc/ssl/unissh/privkey.pem;
+
+    ssl_protocols       TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers off;
+    ssl_session_cache   shared:UniSSH:10m;
+    ssl_session_timeout 1d;
+    ssl_session_tickets off;
+    # OCSP stapling (needs a resolver; harmless to drop if your CA has no OCSP):
+    # ssl_stapling on;
+    # ssl_stapling_verify on;
+    # ssl_trusted_certificate /etc/ssl/unissh/chain.pem;
+    # resolver 1.1.1.1 9.9.9.9 valid=300s;
+
+    # --- Security headers (mirrors deploy/Caddyfile) --------------------------
+    # `always` so they are present on error responses too. NOTE: nginx's
+    # add_header does not inherit into a location that declares its own — if you
+    # add a header inside a location below, repeat this WHOLE block there.
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "no-referrer" always;
+    add_header Cross-Origin-Opener-Policy "same-origin" always;
+    add_header Cross-Origin-Resource-Policy "same-origin" always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header Cache-Control $unissh_cache_control always;
+    server_tokens off;
+
+    # Must be >= the server's limits.max_body_bytes (default 16 MiB), or a legal
+    # push is rejected by nginx with 413 before the server ever sees it.
+    client_max_body_size 16m;
+
+    gzip on;
+    gzip_types text/css application/javascript application/json image/svg+xml application/wasm;
+    gzip_min_length 1024;
+
+    # --- API: /v1/*, /healthz, /readyz -> the UniSSH server -------------------
+    location ~ ^/(v1/|healthz$|readyz$) {
+        proxy_pass http://127.0.0.1:8443;
+        proxy_http_version 1.1;
+
+        proxy_set_header Host              $host;
+        # The server (trust_proxy=true) takes the RIGHTMOST element as the client
+        # IP for per-IP rate limiting. $proxy_add_x_forwarded_for appends
+        # $remote_addr on the right, so a client-supplied XFF cannot displace it.
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host  $host;
+
+        # Sync pushes/pulls can be large; don't cut them off mid-transfer.
+        proxy_read_timeout    120s;
+        proxy_send_timeout    120s;
+        proxy_request_buffering off;
+    }
+
+    # --- Admin SPA ------------------------------------------------------------
+    root /var/www/unissh;
+    index index.html;
+
+    # Hashed filenames — never fall back to the shell for a missing asset, or a
+    # stale upgrade serves index.html where JS is expected.
+    location /assets/ {
+        try_files $uri =404;
+    }
+
+    # History-API fallback: every non-file path renders the SPA shell. The shell
+    # is `no-store` via the map above, so an upgrade is picked up on next load
+    # instead of pointing returning users at deleted asset hashes.
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/deploy/nginx/unissh-static-spa.conf
+++ b/deploy/nginx/unissh-static-spa.conf
@@ -21,7 +21,7 @@
 #        docker cp "$cid:/srv/." /var/www/unissh/
 #        docker rm "$cid"
 #      (Repeat after every upgrade — the SPA is versioned with the server.)
-#   3. Copy this file to /etc/nginx/sites-available/unissh.conf (or conf.d/),
+#   3. Copy this file to /etc/nginx/conf.d/unissh.conf,
 #      edit server_name + the two ssl_certificate paths, then:
 #        nginx -t && systemctl reload nginx
 #

--- a/deploy/nginx/unissh.conf
+++ b/deploy/nginx/unissh.conf
@@ -1,59 +1,37 @@
 # =============================================================================
-# UniSSH — nginx server block (TLS termination + admin SPA + API proxy).
+# UniSSH — nginx server block: TLS in front of the bundled stack.
 #
-# For operators who already run nginx with their own certificates and do not
-# want the bundled Caddy. It is the exact job deploy/Caddyfile does, expressed
-# in nginx: terminate TLS, serve the admin SPA from disk, and reverse-proxy the
-# API to the UniSSH server over loopback.
+# The simple variant, and the one to start from. nginx does ONE job — terminate
+# TLS with your certificate and forward everything to the stack's own front door
+# (the bundled Caddy, switched to plain HTTP on loopback), which keeps serving
+# the admin SPA and proxying the API exactly as it does in the default install:
 #
-#   client ──TLS──► nginx ──plain HTTP──► 127.0.0.1:8443 (unissh-server)
-#                     └─ SPA from /var/www/unissh
+#   client ──TLS──► nginx ──HTTP──► 127.0.0.1:8080 (caddy) ──► server:8443
+#
+# Nothing here has to be re-synced on upgrade: the SPA travels inside the image.
 #
 # Install:
-#   1. Start the server WITHOUT the bundled Caddy — it publishes 127.0.0.1:8443:
-#        docker compose -f compose.prod.yml -f deploy/compose.reverse-proxy.yml up -d
-#   2. Put the admin SPA on disk (the files live in the caddy image at /srv):
-#        cid=$(docker create ghcr.io/goduni/unissh-caddy:latest)
-#        docker cp "$cid:/srv/." /var/www/unissh/
-#        docker rm "$cid"
-#      (Repeat after every upgrade — the SPA is versioned with the server.)
-#   3. Copy this file to /etc/nginx/sites-available/unissh.conf (or conf.d/),
-#      edit server_name + the two ssl_certificate paths, then:
+#   1. Start the stack with the bundled Caddy on loopback HTTP:
+#        docker compose -f compose.prod.yml -f deploy/compose.behind-proxy.yml up -d
+#        curl -i http://127.0.0.1:8080/readyz
+#   2. Copy this file to /etc/nginx/conf.d/unissh.conf, edit server_name and the
+#      two ssl_certificate paths, then:
 #        nginx -t && systemctl reload nginx
 #
-# The SPA and /v1 MUST stay on ONE origin: the panel calls the API with a
-# relative base, so same-origin is what keeps CORS disabled server-side. Do not
-# split them across two hostnames.
+# If you would rather have nginx serve the SPA from its own docroot and talk to
+# the server directly — one hop instead of two, at the cost of re-copying the
+# panel on every upgrade — use unissh-static-spa.conf in this directory instead.
+#
+# Forward ALL paths, not just /v1: the SPA and the API must share one origin, or
+# the panel needs CORS enabled server-side and a weaker CSP.
 # =============================================================================
 
-# Some distributions' mime.types predate WebAssembly. The panel's crypto module
-# is loaded with WebAssembly.instantiateStreaming, which REJECTS anything not
-# served as application/wasm — the panel would fail to unlock with a console
-# error and no other symptom. On an nginx whose mime.types already has it, this
-# is a no-op that logs one `duplicate extension "wasm"` warning at config test —
-# expected, and cheaper than the failure it prevents.
-types {
-    application/wasm wasm;
-}
-
-# Cache policy as a map rather than per-location `add_header`, because in nginx
-# an `add_header` inside a location DROPS every header inherited from the server
-# block — a per-location cache header would silently strip the CSP from exactly
-# the responses that need it. One header, set once, computed from the path:
-# hashed assets are immutable, everything else (the SPA shell, the API) is not.
-map $uri $unissh_cache_control {
-    default          "no-store";
-    ~^/assets/       "public, max-age=31536000, immutable";
-}
-
-# --- :80 — redirect only. ----------------------------------------------------
-# Keep it: it is also where an HTTP-01 ACME challenge is answered if you renew
-# with certbot/acme.sh on this host.
 server {
     listen 80;
     listen [::]:80;
     server_name unissh.example.com;
 
+    # Keep this location if you renew with certbot/acme.sh on this host.
     location /.well-known/acme-challenge/ {
         root /var/www/html;
     }
@@ -80,43 +58,22 @@ server {
     ssl_session_cache   shared:UniSSH:10m;
     ssl_session_timeout 1d;
     ssl_session_tickets off;
-    # OCSP stapling (needs a resolver; harmless to drop if your CA has no OCSP):
-    # ssl_stapling on;
-    # ssl_stapling_verify on;
-    # ssl_trusted_certificate /etc/ssl/unissh/chain.pem;
-    # resolver 1.1.1.1 9.9.9.9 valid=300s;
 
-    # --- Security headers (mirrors deploy/Caddyfile) --------------------------
-    # `always` so they are present on error responses too. NOTE: nginx's
-    # add_header does not inherit into a location that declares its own — if you
-    # add a header inside a location below, repeat this WHOLE block there.
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'" always;
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header X-Frame-Options "DENY" always;
-    add_header Referrer-Policy "no-referrer" always;
-    add_header Cross-Origin-Opener-Policy "same-origin" always;
-    add_header Cross-Origin-Resource-Policy "same-origin" always;
-    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-    add_header Cache-Control $unissh_cache_control always;
-    server_tokens off;
-
-    # Must be >= the server's limits.max_body_bytes (default 16 MiB), or a legal
-    # push is rejected by nginx with 413 before the server ever sees it.
+    # Must be >= the server's limits.max_body_bytes (16 MiB default), or a legal
+    # push is rejected with 413 before the server ever sees it.
     client_max_body_size 16m;
 
-    gzip on;
-    gzip_types text/css application/javascript application/json image/svg+xml application/wasm;
-    gzip_min_length 1024;
+    server_tokens off;
 
-    # --- API: /v1/*, /healthz, /readyz -> the UniSSH server -------------------
-    location ~ ^/(v1/|healthz$|readyz$) {
-        proxy_pass http://127.0.0.1:8443;
+    # Security headers (CSP, nosniff, frame-ancestors, HSTS…) are already set by
+    # the Caddy inside the stack and pass through untouched — do NOT re-add them
+    # here, or every response carries two copies and the stricter one is not
+    # necessarily what the browser applies.
+    location / {
+        proxy_pass http://127.0.0.1:8080;
         proxy_http_version 1.1;
 
         proxy_set_header Host              $host;
-        # The server (trust_proxy=true) takes the RIGHTMOST element as the client
-        # IP for per-IP rate limiting. $proxy_add_x_forwarded_for appends
-        # $remote_addr on the right, so a client-supplied XFF cannot displace it.
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-Host  $host;
@@ -126,21 +83,17 @@ server {
         proxy_send_timeout    120s;
         proxy_request_buffering off;
     }
-
-    # --- Admin SPA ------------------------------------------------------------
-    root /var/www/unissh;
-    index index.html;
-
-    # Hashed filenames — never fall back to the shell for a missing asset, or a
-    # stale upgrade serves index.html where JS is expected.
-    location /assets/ {
-        try_files $uri =404;
-    }
-
-    # History-API fallback: every non-file path renders the SPA shell. The shell
-    # is `no-store` via the map above, so an upgrade is picked up on next load
-    # instead of pointing returning users at deleted asset hashes.
-    location / {
-        try_files $uri $uri/ /index.html;
-    }
 }
+
+# -----------------------------------------------------------------------------
+# One caveat of this two-hop layout: the server reads the RIGHTMOST
+# X-Forwarded-For element, and the last hop to write that header is the stack's
+# Caddy — which, not being told to trust an upstream, replaces what nginx sent
+# with its own peer. So every request looks like it came from one address.
+# (A client-forged XFF is dropped the same way, which is the good half of this.)
+# Per-IP rate limiting
+# (limits.rate_limit_per_ip_rps, 20/s by default) therefore applies to the whole
+# instance rather than per client. Either raise that limit, or use
+# unissh-static-spa.conf, where nginx is the only hop and the server sees real
+# client addresses.
+# -----------------------------------------------------------------------------

--- a/deploy/nginx/unissh.conf
+++ b/deploy/nginx/unissh.conf
@@ -1,0 +1,146 @@
+# =============================================================================
+# UniSSH — nginx server block (TLS termination + admin SPA + API proxy).
+#
+# For operators who already run nginx with their own certificates and do not
+# want the bundled Caddy. It is the exact job deploy/Caddyfile does, expressed
+# in nginx: terminate TLS, serve the admin SPA from disk, and reverse-proxy the
+# API to the UniSSH server over loopback.
+#
+#   client ──TLS──► nginx ──plain HTTP──► 127.0.0.1:8443 (unissh-server)
+#                     └─ SPA from /var/www/unissh
+#
+# Install:
+#   1. Start the server WITHOUT the bundled Caddy — it publishes 127.0.0.1:8443:
+#        docker compose -f compose.prod.yml -f deploy/compose.reverse-proxy.yml up -d
+#   2. Put the admin SPA on disk (the files live in the caddy image at /srv):
+#        cid=$(docker create ghcr.io/goduni/unissh-caddy:latest)
+#        docker cp "$cid:/srv/." /var/www/unissh/
+#        docker rm "$cid"
+#      (Repeat after every upgrade — the SPA is versioned with the server.)
+#   3. Copy this file to /etc/nginx/sites-available/unissh.conf (or conf.d/),
+#      edit server_name + the two ssl_certificate paths, then:
+#        nginx -t && systemctl reload nginx
+#
+# The SPA and /v1 MUST stay on ONE origin: the panel calls the API with a
+# relative base, so same-origin is what keeps CORS disabled server-side. Do not
+# split them across two hostnames.
+# =============================================================================
+
+# Some distributions' mime.types predate WebAssembly. The panel's crypto module
+# is loaded with WebAssembly.instantiateStreaming, which REJECTS anything not
+# served as application/wasm — the panel would fail to unlock with a console
+# error and no other symptom. On an nginx whose mime.types already has it, this
+# is a no-op that logs one `duplicate extension "wasm"` warning at config test —
+# expected, and cheaper than the failure it prevents.
+types {
+    application/wasm wasm;
+}
+
+# Cache policy as a map rather than per-location `add_header`, because in nginx
+# an `add_header` inside a location DROPS every header inherited from the server
+# block — a per-location cache header would silently strip the CSP from exactly
+# the responses that need it. One header, set once, computed from the path:
+# hashed assets are immutable, everything else (the SPA shell, the API) is not.
+map $uri $unissh_cache_control {
+    default          "no-store";
+    ~^/assets/       "public, max-age=31536000, immutable";
+}
+
+# --- :80 — redirect only. ----------------------------------------------------
+# Keep it: it is also where an HTTP-01 ACME challenge is answered if you renew
+# with certbot/acme.sh on this host.
+server {
+    listen 80;
+    listen [::]:80;
+    server_name unissh.example.com;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/html;
+    }
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    http2 on;                       # nginx >= 1.25; older: `listen 443 ssl http2;`
+    server_name unissh.example.com;
+
+    # --- TLS: your existing certificate ---------------------------------------
+    # fullchain = leaf FIRST, then intermediates. Serving the leaf alone is the
+    # classic "works in my browser, fails in the client" bug: browsers often
+    # patch a missing intermediate from cache, non-browser clients never do.
+    ssl_certificate     /etc/ssl/unissh/fullchain.pem;
+    ssl_certificate_key /etc/ssl/unissh/privkey.pem;
+
+    ssl_protocols       TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers off;
+    ssl_session_cache   shared:UniSSH:10m;
+    ssl_session_timeout 1d;
+    ssl_session_tickets off;
+    # OCSP stapling (needs a resolver; harmless to drop if your CA has no OCSP):
+    # ssl_stapling on;
+    # ssl_stapling_verify on;
+    # ssl_trusted_certificate /etc/ssl/unissh/chain.pem;
+    # resolver 1.1.1.1 9.9.9.9 valid=300s;
+
+    # --- Security headers (mirrors deploy/Caddyfile) --------------------------
+    # `always` so they are present on error responses too. NOTE: nginx's
+    # add_header does not inherit into a location that declares its own — if you
+    # add a header inside a location below, repeat this WHOLE block there.
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "no-referrer" always;
+    add_header Cross-Origin-Opener-Policy "same-origin" always;
+    add_header Cross-Origin-Resource-Policy "same-origin" always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header Cache-Control $unissh_cache_control always;
+    server_tokens off;
+
+    # Must be >= the server's limits.max_body_bytes (default 16 MiB), or a legal
+    # push is rejected by nginx with 413 before the server ever sees it.
+    client_max_body_size 16m;
+
+    gzip on;
+    gzip_types text/css application/javascript application/json image/svg+xml application/wasm;
+    gzip_min_length 1024;
+
+    # --- API: /v1/*, /healthz, /readyz -> the UniSSH server -------------------
+    location ~ ^/(v1/|healthz$|readyz$) {
+        proxy_pass http://127.0.0.1:8443;
+        proxy_http_version 1.1;
+
+        proxy_set_header Host              $host;
+        # The server (trust_proxy=true) takes the RIGHTMOST element as the client
+        # IP for per-IP rate limiting. $proxy_add_x_forwarded_for appends
+        # $remote_addr on the right, so a client-supplied XFF cannot displace it.
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host  $host;
+
+        # Sync pushes/pulls can be large; don't cut them off mid-transfer.
+        proxy_read_timeout    120s;
+        proxy_send_timeout    120s;
+        proxy_request_buffering off;
+    }
+
+    # --- Admin SPA ------------------------------------------------------------
+    root /var/www/unissh;
+    index index.html;
+
+    # Hashed filenames — never fall back to the shell for a missing asset, or a
+    # stale upgrade serves index.html where JS is expected.
+    location /assets/ {
+        try_files $uri =404;
+    }
+
+    # History-API fallback: every non-file path renders the SPA shell. The shell
+    # is `no-store` via the map above, so an upgrade is picked up on next load
+    # instead of pointing returning users at deleted asset hashes.
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -72,6 +72,7 @@ export default defineConfig({
             { label: 'Build from source', slug: 'operations/build' },
             { label: 'Server configuration', slug: 'operations/configuration' },
             { label: 'Docker Compose deployment', slug: 'operations/deploy' },
+            { label: 'Deployment scenarios', slug: 'operations/deploy-scenarios' },
             { label: 'CI/CD & releases', slug: 'operations/ci-cd' },
             { label: 'Backups & anti-rollback restore', slug: 'operations/backups' },
           ],

--- a/website/src/content/docs/operations/deploy-scenarios.md
+++ b/website/src/content/docs/operations/deploy-scenarios.md
@@ -3,7 +3,9 @@ title: Deployment scenarios
 description: Four ways to put TLS in front of a self-hosted UniSSH server — Caddy with automatic ACME, Caddy with certificates you already have, your own nginx, and a LAN deployment behind a self-signed internal CA.
 ---
 
-The [Docker Compose deployment](../deploy/) ships one opinionated path: Caddy in front, a certificate from Let's Encrypt, the admin panel and the API on one origin. This page covers the other four situations operators actually land in — an existing certificate, an existing nginx, no proxy at all, and a LAN with no public DNS.
+The [Docker Compose deployment](../deploy/) ships one opinionated path: Caddy in front, a certificate from Let's Encrypt, the admin panel and the API on one origin. This page covers the situations operators land in instead — a certificate you already hold, a proxy you already run (nginx, Traefik, Cloudflare), a LAN with no public DNS, and no proxy at all.
+
+Every configuration file referenced here lives in the repository and was verified against live nginx, Traefik and Caddy containers rather than written from memory.
 
 Everything below changes **only the front door**. The UniSSH server itself is unchanged: plain HTTP on an internal network, `trust_proxy = true`, no ACME (`acme = true` is a hard startup error). Whatever terminates TLS is the only piece that differs.
 
@@ -30,11 +32,13 @@ Everything else — port, path, hostname — is yours to choose.
 | --- | --- | --- |
 | Public DNS name, want certificates handled for you | [1 — Caddy + ACME](#scenario-1--caddy--automatic-acme-default) | Caddy (automatic) |
 | You already hold a certificate (corporate CA, wildcard, DNS-01, certbot) | [2 — Caddy + your files](#scenario-2--caddy-with-certificates-you-already-have) | Caddy (files) |
-| nginx already runs on this host and terminates TLS | [3 — your own nginx](#scenario-3--your-own-nginx-in-front) | nginx |
+| A proxy already terminates TLS on this host (nginx, HAProxy, a tunnel) | [3a — TLS-only proxy in front](#scenario-3a--a-proxy-in-front-of-the-bundled-stack-recommended) | your proxy |
+| …and the server must see real client IPs | [3b — the proxy replaces Caddy](#scenario-3b--the-proxy-replaces-caddy-one-hop) | your proxy |
+| Traefik with Docker labels | [3c — Traefik](#scenario-3c--traefik) | Traefik |
 | No public DNS at all: LAN, air-gapped, IP-only | [4 — self-signed internal CA](#scenario-4--lan--air-gapped-self-signed-internal-ca) | Caddy (internal CA) |
 | No proxy wanted; API only, no admin panel | [5 — the server terminates TLS](#scenario-5--no-proxy-the-server-terminates-tls-itself) | the server (rustls) |
 
-Scenarios 1, 2 and 4 keep the bundled Caddy and differ by one line in `.env`. Scenarios 3 and 5 replace the front door.
+Scenarios 1, 2 and 4 differ by one line in `.env`. Scenarios 3a and 3c keep the bundled Caddy but move TLS to a proxy you already run; 3b and 5 replace the front door outright.
 
 ---
 
@@ -91,23 +95,59 @@ Relative host paths in the override resolve against the **first** `-f` file's di
 
 ---
 
-## Scenario 3 — your own nginx in front
+## Scenario 3a — a proxy in front of the bundled stack (recommended)
 
-For hosts where nginx already terminates TLS for other sites. The job is the same one Caddy does: **terminate TLS, serve the admin SPA from disk, reverse-proxy the API to the server.**
+The layout to reach for when something already owns ports 80/443 on the host. Your proxy does exactly one job — terminate TLS with your certificate and forward **everything** — and the stack's own front door keeps doing the rest:
+
+```
+client ──TLS──► your proxy ──HTTP──► 127.0.0.1:8080 (caddy) ──► server:8443
+```
+
+Setting Caddy's site address to `:80` turns it into a plain-HTTP internal front: no ACME, no internal CA, still serving the admin SPA and still proxying `/v1`, `/healthz`, `/readyz`. That is what `deploy/compose.behind-proxy.yml` does:
+
+```bash
+docker compose -f compose.prod.yml -f deploy/compose.behind-proxy.yml up -d
+curl -i http://127.0.0.1:8080/           # the SPA
+curl -i http://127.0.0.1:8080/readyz     # proxied to the server
+```
+
+Then install [`deploy/nginx/unissh.conf`](https://github.com/goduni/unissh/blob/main/deploy/nginx/unissh.conf) — TLS plus a single `proxy_pass`, because the security headers, the SPA routing and the API proxying all arrive from inside the stack:
+
+```bash
+sudo cp deploy/nginx/unissh.conf /etc/nginx/conf.d/unissh.conf
+sudo $EDITOR /etc/nginx/conf.d/unissh.conf     # server_name + the two cert paths
+sudo nginx -t && sudo systemctl reload nginx
+```
+
+**Why this one and not 3b.** The admin panel is versioned with the server and travels inside the image, so `docker compose pull && up -d` upgrades both together. Nothing on your disk to re-sync, nothing to skew.
+
+**Forward every path, not just `/v1`.** The SPA and the API must share one origin — that is what keeps CORS off server-side and the CSP tight.
+
+:::caution[The trade-off: the server stops seeing client IPs]
+The server takes the **rightmost** `X-Forwarded-For` element as the client address, and the last hop to write that header is the stack's Caddy, which — not being configured to trust an upstream — replaces whatever your proxy sent with its own peer. Every request then looks like it came from one address, so the per-IP rate limit (`limits.rate_limit_per_ip_rps`, 20/s) applies **instance-wide** rather than per client.
+
+For a small team that is usually fine; raise the limit if it isn't. If you need real client addresses (rate limiting, access logs, fail2ban), use [3b](#scenario-3b--the-proxy-replaces-caddy-one-hop). The upside of the same behaviour: a client-forged `X-Forwarded-For` never reaches the server either.
+:::
+
+---
+
+## Scenario 3b — the proxy replaces Caddy (one hop)
+
+nginx does the whole job the Caddyfile does: TLS, the SPA from its own docroot, the API proxied straight to the server. One hop, so the server sees real client addresses.
 
 ```
 client ──TLS──► nginx ──plain HTTP──► 127.0.0.1:8443 (unissh-server)
                   └─ SPA from /var/www/unissh
 ```
 
-**1. Start the stack without the bundled Caddy.** The `deploy/compose.reverse-proxy.yml` override parks Caddy behind a profile nobody enables (so ports 80/443 stay free) and publishes the API on loopback only:
+**1. Start the stack without the bundled Caddy.** `deploy/compose.reverse-proxy.yml` parks it behind a profile nobody enables (so 80/443 stay free) and publishes the API on loopback only:
 
 ```bash
 docker compose -f compose.prod.yml -f deploy/compose.reverse-proxy.yml up -d
 curl -i http://127.0.0.1:8443/readyz     # HTTP/1.1 200 OK (empty body)
 ```
 
-**2. Put the admin SPA on disk.** Its files live inside the caddy image at `/srv`; copy them out once per upgrade:
+**2. Put the admin SPA on disk.** Its files live inside the caddy image at `/srv`:
 
 ```bash
 cid=$(docker create ghcr.io/goduni/unissh-caddy:latest)
@@ -116,26 +156,55 @@ sudo docker cp "$cid:/srv/." /var/www/unissh/
 docker rm "$cid"
 ```
 
-(Or build them yourself — the panel needs its wasm package built first: `just build-wasm && cd server-ui && npm ci && npm run build` → `dist/`. See [Build from source](../build/).)
+**Repeat this on every upgrade.** The panel and the server ship as one version; a stale docroot is the failure mode this scenario buys, and it shows up as odd API errors rather than an obvious version banner. (Building it yourself instead: the panel needs its wasm package first — `just build-wasm && cd server-ui && npm ci && npm run build` → `dist/`. See [Build from source](../build/).)
 
-**3. Install the server block.** [`deploy/nginx/unissh.conf`](https://github.com/goduni/unissh/blob/main/deploy/nginx/unissh.conf) is a complete, tested one — copy it to `/etc/nginx/conf.d/`, edit `server_name` and the two `ssl_certificate` paths, then `nginx -t && systemctl reload nginx`.
+**3. Install the server block.** [`deploy/nginx/unissh-static-spa.conf`](https://github.com/goduni/unissh/blob/main/deploy/nginx/unissh-static-spa.conf) is complete; edit `server_name`, the two `ssl_certificate` paths and `root`, then `nginx -t && systemctl reload nginx`.
 
 Four details in it are load-bearing, whichever proxy you actually use:
 
-- **Same origin for SPA and API.** The panel calls the API with a relative base, so serving both from one hostname is what keeps CORS off server-side. Splitting them across two names means enabling `cors_allowed_origins` and weakening the CSP.
+- **Same origin for SPA and API.** The panel calls the API with a relative base, so one hostname is what keeps CORS off. Splitting them across two names means enabling `cors_allowed_origins` and weakening the CSP.
 - **`application/wasm`.** The panel's crypto module is loaded with `WebAssembly.instantiateStreaming`, which rejects any other content type. Older `mime.types` files have no `wasm` entry, and the only symptom is a panel that never unlocks.
-- **`client_max_body_size 16m`.** It must be at least the server's `limits.max_body_bytes` (16 MiB by default) or nginx returns 413 for a legal push before the server sees it.
-- **`X-Forwarded-For`.** With `trust_proxy = true` the server reads the **rightmost** element as the client IP for per-IP rate limiting. nginx's `$proxy_add_x_forwarded_for` appends the real peer on the right, so a client-supplied header cannot displace it. A proxy that *overwrites* XFF with a client-controlled value would hand every user a way past the rate limit.
+- **`client_max_body_size 16m`.** At least the server's `limits.max_body_bytes` (16 MiB default), or nginx returns 413 for a legal push before the server sees it.
+- **`X-Forwarded-For`.** With `trust_proxy = true` the server reads the **rightmost** element. nginx's `$proxy_add_x_forwarded_for` appends the real peer on the right, so a client-supplied header cannot displace it. A proxy that *overwrites* XFF with a client-controlled value would hand every user a way past the rate limit.
 
-**If your proxy runs in a container**, drop the `ports:` block from the override, attach the proxy to the `unissh` network, and forward to `http://server:8443` by service name — then nothing is host-published at all.
+---
 
-**Invite links.** Nothing derives your public address for you; set it so invites come back with a usable URL:
+## Scenario 3c — Traefik
 
-```bash
-UNISSH__SERVER__PUBLIC_URL=https://unissh.example.com
+Traefik cannot serve static files, so the bundled Caddy stays as the origin (as in [3a](#scenario-3a--a-proxy-in-front-of-the-bundled-stack-recommended)) and Traefik routes to it over a shared Docker network — nothing is host-published at all:
+
+```
+client ──TLS──► traefik ──HTTP──► caddy:80 ──► server:8443
 ```
 
-The same recipe transfers to HAProxy, Traefik or an appliance: TLS in front, one origin, correct `X-Forwarded-For`, a body limit ≥ 16 MiB, `application/wasm` for the SPA.
+`deploy/compose.traefik.yml` carries the labels. In `.env`:
+
+```bash
+TRAEFIK_NETWORK=traefik              # the network your traefik container is on
+UNISSH_HOST=unissh.example.com
+UNISSH_CERTRESOLVER=letsencrypt      # your Traefik's resolver name
+```
+
+```bash
+docker compose -f compose.prod.yml -f deploy/compose.traefik.yml up -d
+```
+
+The integration is four labels — router rule, entrypoint, TLS, and the container-internal port `80`. Adjust the `websecure` entrypoint name to match your Traefik, and delete the `certresolver` label if it gets certificates another way. The two-hop client-IP caveat from 3a applies here too.
+
+HAProxy, Caddy-you-already-run, nginx-proxy-manager, or an appliance follow the same shape as 3a: terminate TLS, forward every path to the stack's front door, keep one origin, allow a 16 MiB body.
+
+---
+
+## Behind a CDN, WAF or tunnel (Cloudflare & co.)
+
+Putting the instance behind Cloudflare — proxied DNS, or a `cloudflared` tunnel with no inbound ports at all — works, and is often the easiest answer when the host has no public IP. Route it exactly like 3a: the tunnel or CDN forwards everything to `127.0.0.1:8080`.
+
+Two things to be deliberate about:
+
+- **The TLS terminator sees your bearer tokens.** Whoever terminates TLS — Cloudflare, your company's WAF, a shared proxy — sees the API traffic in the clear: session tokens and metadata. It does **not** see vault contents: those are ciphertext the server itself cannot read, so the zero-knowledge guarantee is unaffected either way. But an access token is enough to act as a device against the server, so terminating TLS at a third party is a real trust decision, not a formality. Terminating at your own edge (3a/3b) keeps that to yourself.
+- **Body limits and caching.** The proxy must allow a 16 MiB request body (Cloudflare's free plan caps at 100 MB — fine), and must not cache `/v1` responses. Leave `/v1` uncached; the SPA's hashed assets are safe to cache.
+
+If the CDN also injects `X-Forwarded-For`, the note in 3a still applies: with the bundled Caddy in the chain, the server sees one address regardless.
 
 ---
 
@@ -189,7 +258,7 @@ curl -v https://unissh.local/readyz     # must succeed with NO -k
 ```
 
 :::caution[Mobile clients cannot use a private CA]
-Android does not let apps trust user-installed CAs by default, and iOS requires the profile to be installed *and* enabled under Certificate Trust Settings. If phones or tablets are part of the plan, do not rely on an internal CA — get a real certificate for a real name (a public CA with DNS-01 works fine for a host that is not reachable from the internet) and use [scenario 2](#scenario-2--caddy-with-certificates-you-already-have).
+Android does not let apps trust user-installed CAs by default, and iOS requires the profile to be installed *and* enabled under Certificate Trust Settings. If phones or tablets are part of the plan, do not rely on an internal CA — get a real certificate for a real name and use [scenario 2](#scenario-2--caddy-with-certificates-you-already-have). A public CA issues one for a host that is not reachable from the internet via the **DNS-01** challenge — obtain it out of band with certbot/lego/acme.sh and drop the files in. The shipped Caddy image cannot do DNS-01 itself: those challenges need a provider plugin compiled in with `xcaddy`, and this image has none.
 :::
 
 If the CA root cannot be distributed at all, the remaining supported option is **loopback**: reach the server through an SSH tunnel and point the client at `http://127.0.0.1:<port>` — loopback plaintext is allowed precisely because it never touches a network.
@@ -233,7 +302,46 @@ There is **no admin panel** — the SPA is served by the front door, which no lo
 
 Setting `trust_proxy = false` matters here: with nothing in front, an `X-Forwarded-For` header can only have come from the client, so trusting it would let anyone forge their own IP and evade rate limiting.
 
+### Without Docker at all
+
+No server binaries are published — the release artifacts are the client apps and the two container images — so a bare-metal install means [building from source](../build/) (`cargo build --release -p unissh-server` → `target/release/unissh-server`) and running it under an init system. The config above applies unchanged, via `config.toml` or the same `UNISSH__*` environment keys:
+
+```ini
+# /etc/systemd/system/unissh-server.service
+[Unit]
+Description=UniSSH server
+After=network-online.target
+
+[Service]
+ExecStart=/usr/local/bin/unissh-server serve --config /etc/unissh/config.toml
+User=unissh
+Environment=UNISSH__SERVER__TLS_CERT=/etc/unissh/fullchain.pem
+Environment=UNISSH__SERVER__TLS_KEY=/etc/unissh/privkey.pem
+Restart=on-failure
+# The key must be readable by User= and nothing else.
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+StateDirectory=unissh
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Point `[db].url` at `/var/lib/unissh/unissh.db` (the `StateDirectory`), and remember there is no admin panel on this path either — the SPA needs a web server. Upgrades are yours to drive: rebuild, replace the binary, restart. The container images exist so that most operators don't have to.
+
 ---
+
+## Constraints worth knowing before you commit
+
+- **The site must live at the root of its hostname.** `https://unissh.example.com/` works; `https://example.com/unissh/` is not a tested layout. Give the instance its own hostname (or a subdomain) rather than a path on a shared one.
+- **A non-standard port is fine, everywhere except ACME.** `https://unissh.example.com:8443` works — clients accept the port, just set `UNISSH__SERVER__PUBLIC_URL` to match so invite links carry it. But Caddy's HTTP-01 challenge needs port 80 reachable, so on a host where 80 is taken, use [scenario 2](#scenario-2--caddy-with-certificates-you-already-have) or DNS-01 out of band.
+- **The panel is versioned with the server.** They ship as one image pair. Any layout that copies the SPA onto your own disk ([3b](#scenario-3b--the-proxy-replaces-caddy-one-hop)) has to re-copy it on every upgrade.
+- **One trusted hop.** The server assumes exactly one proxy between it and the client when it reads `X-Forwarded-For`. Two hops is supported and common ([3a](#scenario-3a--a-proxy-in-front-of-the-bundled-stack-recommended)), it just costs you per-client rate limiting.
+- **Whoever terminates TLS sees session tokens** — not vault contents, which are ciphertext end to end. Relevant when that terminator is someone else's infrastructure.
+- **Mobile clients need a publicly-rooted certificate.** A private CA is a desktop-only answer.
+- **What must be reachable:** 443 (and 80 only for ACME HTTP-01 and the redirect). The server's own port and the metrics port stay on the internal network in every scenario above; publishing them is never required.
 
 ## Troubleshooting
 
@@ -247,9 +355,13 @@ Setting `trust_proxy = false` matters here: with nothing in front, an `X-Forward
 
 **Caddy cannot get an ACME certificate** — port 80 must be reachable from the internet for HTTP-01, and public DNS must resolve to this host. On a private network, use scenario 2 or 4 instead.
 
-**The admin panel loads but never unlocks** — the `.wasm` file is being served with the wrong content type. Check `curl -I https://<host>/assets/*.wasm | grep content-type`; it must be `application/wasm` ([scenario 3](#scenario-3--your-own-nginx-in-front)).
+**The admin panel loads but never unlocks** — the `.wasm` file is being served with the wrong content type. Check `curl -I https://<host>/assets/*.wasm | grep content-type`; it must be `application/wasm` ([scenario 3b](#scenario-3b--the-proxy-replaces-caddy-one-hop)).
 
 **Pushes fail with 413** — the proxy's body limit is below the server's `limits.max_body_bytes` (16 MiB default). Raise `client_max_body_size` (nginx) to match.
+
+**The panel shows an older version than the server** — a docroot copy of the SPA that was not refreshed after an upgrade ([3b](#scenario-3b--the-proxy-replaces-caddy-one-hop)). Re-copy `/srv` out of the current caddy image.
+
+**Everything 404s through your proxy** — the proxy is forwarding only `/v1` and not the SPA paths, or (in [3a](#scenario-3a--a-proxy-in-front-of-the-bundled-stack-recommended)) `UNISSH_DOMAIN` is still a hostname rather than `:80`, so the bundled Caddy is matching on a name your proxy doesn't send. Forward every path, and check `docker compose logs caddy`.
 
 **Rate limiting hits the wrong client** — either `trust_proxy` is true with nothing in front of the server, or the proxy is not appending the real peer to `X-Forwarded-For`. The server reads the rightmost element.
 

--- a/website/src/content/docs/operations/deploy-scenarios.md
+++ b/website/src/content/docs/operations/deploy-scenarios.md
@@ -1,65 +1,62 @@
 ---
 title: Deployment scenarios
-description: Four ways to put TLS in front of a self-hosted UniSSH server — Caddy with automatic ACME, Caddy with certificates you already have, your own nginx, and a LAN deployment behind a self-signed internal CA.
+description: Five ways to put TLS in front of a self-hosted UniSSH server — automatic certificates, certificates you already have, a proxy you already run, a LAN with no public DNS, and no proxy at all.
 ---
 
-The [Docker Compose deployment](../deploy/) ships one opinionated path: Caddy in front, a certificate from Let's Encrypt, the admin panel and the API on one origin. This page covers the situations operators land in instead — a certificate you already hold, a proxy you already run (nginx, Traefik, Cloudflare), a LAN with no public DNS, and no proxy at all.
+The [Docker Compose deployment](../deploy/) ships one path: Caddy in front, an automatic Let's Encrypt certificate, panel and API on one origin. This page covers what to do when your situation is different.
 
-Every configuration file referenced here lives in the repository and was verified against live nginx, Traefik and Caddy containers rather than written from memory.
+## Find your situation
 
-Everything below changes **only the front door**. The UniSSH server itself is unchanged: plain HTTP on an internal network, `trust_proxy = true`, no ACME (`acme = true` is a hard startup error). Whatever terminates TLS is the only piece that differs.
+| | Scenario |
+| --- | --- |
+| Public domain, let it handle certificates | **[1 — automatic](#1--automatic-certificates)** |
+| You already hold a certificate | **[2 — your own certificate](#2--your-own-certificate)** |
+| Something already owns ports 80/443 here | **[3 — behind a proxy you run](#3--behind-a-proxy-you-run)** |
+| LAN, air-gapped, IP only — no public DNS | **[4 — private CA](#4--private-ca-lan--air-gapped)** |
+| One admin, no panel, no proxy | **[5 — no proxy at all](#5--no-proxy-at-all)** |
 
-## What the client requires
+In every one of them the UniSSH server itself is identical — plain HTTP on an internal network, `trust_proxy = true`, never any ACME. Only the front door changes.
 
-Before picking a scenario, know the two rules the desktop and mobile clients enforce. They are what make a "quick" deployment fail later.
+## Two rules the client enforces
 
-1. **The server URL must be `https://`.** Plain `http://` is accepted only for loopback (`localhost`, `127.x`, `[::1]`) — the connection carries bearer tokens, so a plaintext hop to a real host would hand an on-path attacker a working session. The client fails with:
+Neither is configurable, and a deployment that ignores them fails at the last step rather than the first.
+
+1. **`https://` only.** Plain `http://` is accepted for loopback (`localhost`, `127.x`, `[::1]`) and nothing else — that connection carries bearer tokens. The refusal reads:
 
    ```
    refusing plaintext http:// to non-loopback host "10.0.0.5:8443":
    use https:// so tokens and data are encrypted in transit
    ```
 
-   This is not a setting. There is no flag to turn it off.
-
-2. **The certificate must verify against the machine's OS trust store.** The client uses the platform verifier — the same roots your browser and `curl` use on that machine — and offers no "continue anyway" prompt. A public CA works out of the box; a private or self-signed CA works once its **root** is installed on each client machine ([scenario 4](#scenario-4--lan--air-gapped-self-signed-internal-ca)).
-
-Everything else — port, path, hostname — is yours to choose.
-
-## Pick a scenario
-
-| Your situation | Scenario | TLS lives in |
-| --- | --- | --- |
-| Public DNS name, want certificates handled for you | [1 — Caddy + ACME](#scenario-1--caddy--automatic-acme-default) | Caddy (automatic) |
-| You already hold a certificate (corporate CA, wildcard, DNS-01, certbot) | [2 — Caddy + your files](#scenario-2--caddy-with-certificates-you-already-have) | Caddy (files) |
-| A proxy already terminates TLS on this host (nginx, HAProxy, a tunnel) | [3a — TLS-only proxy in front](#scenario-3a--a-proxy-in-front-of-the-bundled-stack-recommended) | your proxy |
-| …and the server must see real client IPs | [3b — the proxy replaces Caddy](#scenario-3b--the-proxy-replaces-caddy-one-hop) | your proxy |
-| Traefik with Docker labels | [3c — Traefik](#scenario-3c--traefik) | Traefik |
-| No public DNS at all: LAN, air-gapped, IP-only | [4 — self-signed internal CA](#scenario-4--lan--air-gapped-self-signed-internal-ca) | Caddy (internal CA) |
-| No proxy wanted; API only, no admin panel | [5 — the server terminates TLS](#scenario-5--no-proxy-the-server-terminates-tls-itself) | the server (rustls) |
-
-Scenarios 1, 2 and 4 differ by one line in `.env`. Scenarios 3a and 3c keep the bundled Caddy but move TLS to a proxy you already run; 3b and 5 replace the front door outright.
+2. **The certificate must verify against the machine's OS trust store.** The client uses the platform verifier — the same roots `curl` uses on that machine — and has no "continue anyway" button. A public CA just works; a private CA works after [scenario 4](#4--private-ca-lan--air-gapped).
 
 ---
 
-## Scenario 1 — Caddy + automatic ACME (default)
+## 1 — Automatic certificates
 
-The shipped path, covered in full on the [Docker Compose deployment](../deploy/) page. `.env`:
+**Use when** the instance has a public DNS name and port 80 is reachable.
 
 ```bash
+# .env
 UNISSH_DOMAIN=unissh.example.com
-UNISSH_TLS_DIRECTIVE=tls you@example.com    # empty is also valid (no expiry notices)
+UNISSH_TLS_DIRECTIVE=tls you@example.com     # the email is optional; it enables expiry notices
 ```
 
-Requires public DNS pointing at the host and port **80** reachable for the challenge and the HTTP→HTTPS redirect. Renewal is automatic and needs no operator action.
+```bash
+docker compose -f compose.prod.yml up -d
+```
+
+Caddy obtains and renews the certificate on its own. The full walkthrough — profiles, first-run claim, backups — is on the [Docker Compose deployment](../deploy/) page.
 
 ---
 
-## Scenario 2 — Caddy with certificates you already have
+## 2 — Your own certificate
 
-For a certificate that does not come from Caddy's own ACME: a corporate/internal CA, a commercial wildcard, a DNS-01 issuance, or a cert renewed on the host by certbot/acme.sh. Caddy still serves the SPA and proxies the API — only where the certificate comes from changes.
+**Use when** the certificate comes from somewhere else: a corporate CA, a commercial wildcard, a DNS-01 issuance, certbot/acme.sh on the host.
 
-**1. Put the two files on the host.** Default location is `./certs` at the repository root:
+Caddy stays the front door; only the source of the certificate changes.
+
+**1.** Put the pair on the host (default location is `./certs` at the repository root):
 
 ```bash
 mkdir -p certs
@@ -68,95 +65,93 @@ cp /path/to/privkey.pem   certs/privkey.pem     # unencrypted PEM
 chmod 600 certs/privkey.pem
 ```
 
-:::caution[Ship the full chain, not just the leaf]
-A leaf-only `cert.pem` frequently works in a browser (which caches intermediates from other sites) and then fails in the UniSSH client, which does not. If in doubt, check with
-`openssl s_client -connect host:443 -showcerts </dev/null` — you should see the leaf **and** every intermediate up to a root your machine trusts.
-:::
-
-**2. Point the TLS knob at them** in `.env`:
+**2.** Point the TLS knob at them:
 
 ```bash
+# .env
 UNISSH_DOMAIN=unissh.example.com
 UNISSH_TLS_DIRECTIVE=tls /certs/fullchain.pem /certs/privkey.pem
-# UNISSH_CERTS_DIR=./certs        # optional: mount some other host directory
+# UNISSH_CERTS_DIR=./certs      # optional: some other host directory
 ```
 
-**3. Start with the cert-mount override** (`deploy/compose.tls-files.yml`, which bind-mounts that directory read-only at `/certs`):
+**3.** Start with the cert-mount override, which bind-mounts that directory read-only at `/certs`:
 
 ```bash
 docker compose -f compose.prod.yml -f deploy/compose.tls-files.yml up -d
-# or, building from source:
-docker compose -f compose.yml -f deploy/compose.tls-files.yml up -d --build
 ```
 
-Relative host paths in the override resolve against the **first** `-f` file's directory (the repository root), which is why the default is `./certs` and not `../certs`.
+:::danger[Renewal is not automatic — wire up the reload]
+Caddy loads these files **once**. Rewriting them on disk changes nothing, and plain `caddy reload` is a no-op because the config is unchanged. Verified by swapping the files under a running container: the original certificate was still on the wire 75 seconds later.
 
-:::danger[Renewal does not happen by itself]
-Caddy loads these files **once**. Rewriting them on disk changes nothing — the old certificate keeps being served, and plain `caddy reload` is a no-op because the config is unchanged. (Both verified against a running container: after swapping the files, the original certificate was still on the wire.) Every renewal must be followed by:
+Every renewal must be followed by one of:
 
 ```bash
 docker compose exec caddy caddy reload --force --config /etc/caddy/Caddyfile
-# or: docker compose restart caddy
+docker compose restart caddy
 ```
 
-Put that in the certbot/acme.sh **deploy hook**. Otherwise the instance serves an expired certificate — and because the client has no "accept anyway", that is a full outage, not a warning.
+Put it in your certbot/acme.sh **deploy hook**. Skip it and the instance serves an expired certificate — which, with no "accept anyway" in the client, is an outage rather than a warning.
 :::
+
+:::note[Ship the full chain]
+A leaf-only file often works in a browser (which caches intermediates from other sites) and then fails in the client, which does not. Check with `openssl s_client -connect host:443 -showcerts </dev/null`.
+:::
+
+Relative paths in the override resolve against the **first** `-f` file's directory — the repository root — which is why the default is `./certs` and not `../certs`.
 
 ---
 
-## Scenario 3a — a proxy in front of the bundled stack (recommended)
+## 3 — Behind a proxy you run
 
-The layout to reach for when something already owns ports 80/443 on the host. Your proxy does exactly one job — terminate TLS with your certificate and forward **everything** — and the stack's own front door keeps doing the rest:
+**Use when** nginx, Traefik, HAProxy, an appliance or a tunnel already owns 80/443 on this host.
+
+### 3a — Your proxy does TLS only (start here)
+
+Set the bundled Caddy's site address to `:80` and it becomes a plain-HTTP internal front: no ACME, no internal CA, still serving the panel and proxying the API. Your proxy terminates TLS and forwards everything to it.
 
 ```
 client ──TLS──► your proxy ──HTTP──► 127.0.0.1:8080 (caddy) ──► server:8443
 ```
 
-Setting Caddy's site address to `:80` turns it into a plain-HTTP internal front: no ACME, no internal CA, still serving the admin SPA and still proxying `/v1`, `/healthz`, `/readyz`. That is what `deploy/compose.behind-proxy.yml` does:
-
 ```bash
 docker compose -f compose.prod.yml -f deploy/compose.behind-proxy.yml up -d
-curl -i http://127.0.0.1:8080/           # the SPA
-curl -i http://127.0.0.1:8080/readyz     # proxied to the server
+curl -i http://127.0.0.1:8080/readyz          # 200, empty body
 ```
 
-Then install [`deploy/nginx/unissh.conf`](https://github.com/goduni/unissh/blob/main/deploy/nginx/unissh.conf) — TLS plus a single `proxy_pass`, because the security headers, the SPA routing and the API proxying all arrive from inside the stack:
+Then install [`deploy/nginx/unissh.conf`](https://github.com/goduni/unissh/blob/main/deploy/nginx/unissh.conf) — TLS plus a single `proxy_pass`, because the routing, the panel and the security headers all arrive from inside the stack:
 
 ```bash
 sudo cp deploy/nginx/unissh.conf /etc/nginx/conf.d/unissh.conf
-sudo $EDITOR /etc/nginx/conf.d/unissh.conf     # server_name + the two cert paths
+sudo $EDITOR /etc/nginx/conf.d/unissh.conf    # server_name + the two cert paths
 sudo nginx -t && sudo systemctl reload nginx
 ```
 
-**Why this one and not 3b.** The admin panel is versioned with the server and travels inside the image, so `docker compose pull && up -d` upgrades both together. Nothing on your disk to re-sync, nothing to skew.
+**Why start here:** the panel is versioned with the server and travels inside the image, so `docker compose pull && up -d` upgrades both. Nothing on your disk to re-sync.
 
-**Forward every path, not just `/v1`.** The SPA and the API must share one origin — that is what keeps CORS off server-side and the CSP tight.
+**Forward every path,** not just `/v1` — the panel and the API must share one origin, which is what keeps CORS off and the CSP tight.
 
-:::caution[The trade-off: the server stops seeing client IPs]
-The server takes the **rightmost** `X-Forwarded-For` element as the client address, and the last hop to write that header is the stack's Caddy, which — not being configured to trust an upstream — replaces whatever your proxy sent with its own peer. Every request then looks like it came from one address, so the per-IP rate limit (`limits.rate_limit_per_ip_rps`, 20/s) applies **instance-wide** rather than per client.
+:::caution[The cost: the server stops seeing client IPs]
+The server takes the **rightmost** `X-Forwarded-For` element, and the last hop to write that header is the stack's Caddy, which — trusting no upstream — replaces whatever your proxy sent with its own peer. Every request then looks like it came from one address, so the per-IP rate limit (`limits.rate_limit_per_ip_rps`, 20/s) applies **instance-wide**.
 
-For a small team that is usually fine; raise the limit if it isn't. If you need real client addresses (rate limiting, access logs, fail2ban), use [3b](#scenario-3b--the-proxy-replaces-caddy-one-hop). The upside of the same behaviour: a client-forged `X-Forwarded-For` never reaches the server either.
+Usually fine for a team; raise the limit if it isn't, or use [3b](#3b--your-proxy-replaces-caddy). Configuring Caddy's `trusted_proxies` does **not** fix it — tested: the chain is preserved, but the rightmost element is still the inner proxy. The upside of the same behaviour is that a client-forged `X-Forwarded-For` never reaches the server either.
 :::
 
----
+### 3b — Your proxy replaces Caddy
 
-## Scenario 3b — the proxy replaces Caddy (one hop)
-
-nginx does the whole job the Caddyfile does: TLS, the SPA from its own docroot, the API proxied straight to the server. One hop, so the server sees real client addresses.
+**Use when** the server must see real client addresses (per-IP rate limiting, access logs, fail2ban).
 
 ```
 client ──TLS──► nginx ──plain HTTP──► 127.0.0.1:8443 (unissh-server)
-                  └─ SPA from /var/www/unissh
+                  └─ panel from /var/www/unissh
 ```
 
-**1. Start the stack without the bundled Caddy.** `deploy/compose.reverse-proxy.yml` parks it behind a profile nobody enables (so 80/443 stay free) and publishes the API on loopback only:
+**1.** Start without the bundled Caddy — the override parks it and publishes the API on loopback:
 
 ```bash
 docker compose -f compose.prod.yml -f deploy/compose.reverse-proxy.yml up -d
-curl -i http://127.0.0.1:8443/readyz     # HTTP/1.1 200 OK (empty body)
 ```
 
-**2. Put the admin SPA on disk.** Its files live inside the caddy image at `/srv`:
+**2.** Put the panel on disk (its files live in the caddy image at `/srv`):
 
 ```bash
 cid=$(docker create ghcr.io/goduni/unissh-caddy:latest)
@@ -165,30 +160,26 @@ sudo docker cp "$cid:/srv/." /var/www/unissh/
 docker rm "$cid"
 ```
 
-**Repeat this on every upgrade.** The panel and the server ship as one version; a stale docroot is the failure mode this scenario buys, and it shows up as odd API errors rather than an obvious version banner. (Building it yourself instead: the panel needs its wasm package first — `just build-wasm && cd server-ui && npm ci && npm run build` → `dist/`. See [Build from source](../build/).)
+**Repeat that on every upgrade** — panel and server ship as one version, and a stale copy surfaces as odd API errors rather than a version banner. (Building it instead: `just build-wasm && cd server-ui && npm ci && npm run build`. See [Build from source](../build/).)
 
-**3. Install the server block.** [`deploy/nginx/unissh-static-spa.conf`](https://github.com/goduni/unissh/blob/main/deploy/nginx/unissh-static-spa.conf) is complete; edit `server_name`, the two `ssl_certificate` paths and `root`, then `nginx -t && systemctl reload nginx`.
+**3.** Install [`deploy/nginx/unissh-static-spa.conf`](https://github.com/goduni/unissh/blob/main/deploy/nginx/unissh-static-spa.conf), edit `server_name`, the certificate paths and `root`, then `nginx -t && systemctl reload nginx`.
 
-Four details in it are load-bearing, whichever proxy you actually use:
+<details>
+<summary>Four details in that file are load-bearing for any proxy</summary>
 
-- **Same origin for SPA and API.** The panel calls the API with a relative base, so one hostname is what keeps CORS off. Splitting them across two names means enabling `cors_allowed_origins` and weakening the CSP.
+- **One origin for panel and API.** The panel calls the API with a relative base. Two hostnames means enabling `cors_allowed_origins` and a weaker CSP.
 - **`application/wasm`.** The panel's crypto module is loaded with `WebAssembly.instantiateStreaming`, which rejects any other content type. Older `mime.types` files have no `wasm` entry, and the only symptom is a panel that never unlocks.
-- **`client_max_body_size 16m`.** At least the server's `limits.max_body_bytes` (16 MiB default), or nginx returns 413 for a legal push before the server sees it.
-- **`X-Forwarded-For`.** With `trust_proxy = true` the server reads the **rightmost** element. nginx's `$proxy_add_x_forwarded_for` appends the real peer on the right, so a client-supplied header cannot displace it. A proxy that *overwrites* XFF with a client-controlled value would hand every user a way past the rate limit.
+- **`client_max_body_size 16m`.** At least the server's `limits.max_body_bytes`, or a legal push is 413'd before the server sees it.
+- **`X-Forwarded-For`.** The server reads the rightmost element; `$proxy_add_x_forwarded_for` appends the real peer there, so a client-supplied header cannot displace it. A proxy that *overwrites* XFF with a client-controlled value hands every user a way past the rate limit.
 
----
+</details>
 
-## Scenario 3c — Traefik
+### 3c — Traefik
 
-Traefik cannot serve static files, so the bundled Caddy stays as the origin (as in [3a](#scenario-3a--a-proxy-in-front-of-the-bundled-stack-recommended)) and Traefik routes to it over a shared Docker network — nothing is host-published at all:
-
-```
-client ──TLS──► traefik ──HTTP──► caddy:80 ──► server:8443
-```
-
-`deploy/compose.traefik.yml` carries the labels. In `.env`:
+Traefik cannot serve static files, so the bundled Caddy stays as the origin (as in 3a) and Traefik routes to it over a shared Docker network — nothing is host-published.
 
 ```bash
+# .env
 TRAEFIK_NETWORK=traefik              # the network your traefik container is on
 UNISSH_HOST=unissh.example.com
 UNISSH_CERTRESOLVER=letsencrypt      # your Traefik's resolver name
@@ -198,44 +189,30 @@ UNISSH_CERTRESOLVER=letsencrypt      # your Traefik's resolver name
 docker compose -f compose.prod.yml -f deploy/compose.traefik.yml up -d
 ```
 
-The integration is four labels — router rule, entrypoint, TLS, and the container-internal port `80`. Adjust the `websecure` entrypoint name to match your Traefik, and delete the `certresolver` label if it gets certificates another way. The two-hop client-IP caveat from 3a applies here too.
+The integration is four labels — router rule, entrypoint, TLS, and the container-internal port 80. Rename the `websecure` entrypoint to match your Traefik, and delete the `certresolver` label if it gets certificates another way. The client-IP caveat from 3a applies.
 
-HAProxy, Caddy-you-already-run, nginx-proxy-manager, or an appliance follow the same shape as 3a: terminate TLS, forward every path to the stack's front door, keep one origin, allow a 16 MiB body.
+### 3d — Behind a CDN, WAF or tunnel
 
----
+Cloudflare with proxied DNS, or a `cloudflared` tunnel with no inbound ports at all, is often the easiest answer for a host with no public IP. Route it exactly like 3a — forward everything to `127.0.0.1:8080` — and be deliberate about two things:
 
-## Behind a CDN, WAF or tunnel (Cloudflare & co.)
-
-Putting the instance behind Cloudflare — proxied DNS, or a `cloudflared` tunnel with no inbound ports at all — works, and is often the easiest answer when the host has no public IP. Route it exactly like 3a: the tunnel or CDN forwards everything to `127.0.0.1:8080`.
-
-Two things to be deliberate about:
-
-- **The TLS terminator sees your bearer tokens.** Whoever terminates TLS — Cloudflare, your company's WAF, a shared proxy — sees the API traffic in the clear: session tokens and metadata. It does **not** see vault contents: those are ciphertext the server itself cannot read, so the zero-knowledge guarantee is unaffected either way. But an access token is enough to act as a device against the server, so terminating TLS at a third party is a real trust decision, not a formality. Terminating at your own edge (3a/3b) keeps that to yourself.
-- **Body limits and caching.** The proxy must allow a 16 MiB request body (Cloudflare's free plan caps at 100 MB — fine), and must not cache `/v1` responses. Leave `/v1` uncached; the SPA's hashed assets are safe to cache.
-
-If the CDN also injects `X-Forwarded-For`, the note in 3a still applies: with the bundled Caddy in the chain, the server sees one address regardless.
+- **Whoever terminates TLS sees session tokens.** Not vault contents: those are ciphertext the server itself cannot read, so the zero-knowledge guarantee is unaffected. But an access token is enough to act as a device, so terminating TLS at a third party is a real trust decision. Terminating at your own edge keeps it to yourself.
+- **Allow a 16 MiB request body, and do not cache `/v1`.** The panel's hashed assets are safe to cache.
 
 ---
 
-## Scenario 4 — LAN / air-gapped (self-signed internal CA)
+## 4 — Private CA (LAN / air-gapped)
 
-No public DNS means no ACME. Caddy can issue from its own internal CA:
+**Use when** there is no public DNS: a `.local` name or a bare IP.
 
 ```bash
-UNISSH_DOMAIN=unissh.local          # or an IP: 10.0.0.5
+# .env
+UNISSH_DOMAIN=unissh.local      # or 10.0.0.5
 UNISSH_TLS_DIRECTIVE=tls internal
 ```
 
-This works — but it is only half the job, and skipping the other half is the single most common failed self-hosted deployment. **Every client machine must trust that CA root.** The client verifies against the OS trust store and has no "accept anyway" prompt, and (per [What the client requires](#what-the-client-requires)) falling back to `http://` is refused.
+Caddy issues from its own internal CA. That is half the job — **every client machine must trust that root**, or the client refuses the certificate and (per the [two rules](#two-rules-the-client-enforces)) will not fall back to `http://`. Skipping this half is the most common failed self-hosted deployment.
 
-:::note[The `certutil` warning in the Caddy log is a red herring]
-```
-warning: "certutil" is not available, install "certutil" with "apt install libnss3-tools" …
-```
-That is Caddy trying to install its root into the trust store **inside its own container**, where nothing consumes it. It is harmless, installing `certutil` there fixes nothing, and it is unrelated to whether clients trust the certificate.
-:::
-
-**Export the root** (once — it lives in the `caddy-data` volume, which is why that volume must persist):
+**Export the root** (it lives in the `caddy-data` volume, which is why that volume must persist):
 
 ```bash
 docker compose cp caddy:/data/caddy/pki/authorities/local/root.crt ./unissh-root.crt
@@ -260,42 +237,27 @@ sudo security add-trusted-cert -d -r trustRoot \
 Import-Certificate -FilePath unissh-root.crt -CertStoreLocation Cert:\LocalMachine\Root
 ```
 
-Verify from a client before opening the app — `curl` uses the same store:
+Confirm from the client before opening the app — `curl` reads the same store:
 
 ```bash
 curl -v https://unissh.local/readyz     # must succeed with NO -k
 ```
 
-:::caution[Mobile clients cannot use a private CA]
-Android does not let apps trust user-installed CAs by default, and iOS requires the profile to be installed *and* enabled under Certificate Trust Settings. If phones or tablets are part of the plan, do not rely on an internal CA — get a real certificate for a real name and use [scenario 2](#scenario-2--caddy-with-certificates-you-already-have). A public CA issues one for a host that is not reachable from the internet via the **DNS-01** challenge — obtain it out of band with certbot/lego/acme.sh and drop the files in. The shipped Caddy image cannot do DNS-01 itself: those challenges need a provider plugin compiled in with `xcaddy`, and this image has none.
+:::note[`certutil is not available` in the Caddy log is a red herring]
+That is Caddy trying to install its root into the trust store **inside its own container**, where nothing consumes it. Installing `certutil` there fixes nothing and has no bearing on whether clients trust the certificate.
 :::
 
-If the CA root cannot be distributed at all, the remaining supported option is **loopback**: reach the server through an SSH tunnel and point the client at `http://127.0.0.1:<port>` — loopback plaintext is allowed precisely because it never touches a network.
+:::caution[Mobile clients cannot use a private CA]
+Android does not let apps trust user-installed CAs by default, and iOS needs the profile installed *and* enabled under Certificate Trust Settings. If phones are part of the plan, get a real certificate for a real name and use [scenario 2](#2--your-own-certificate). A public CA will issue one for a host that is unreachable from the internet via the **DNS-01** challenge — obtain it out of band with certbot/lego/acme.sh. The shipped Caddy image cannot do DNS-01 itself: those challenges need a provider plugin compiled in with `xcaddy`, and this image has none.
+:::
+
+If the root cannot be distributed at all, the remaining option is **loopback**: reach the server through an SSH tunnel and point the client at `http://127.0.0.1:<port>`, which is allowed precisely because it never touches a network.
 
 ---
 
-## Scenario 5 — no proxy: the server terminates TLS itself
+## 5 — No proxy at all
 
-The smallest possible deployment. The server has in-process rustls; give it a certificate and key and it serves `/v1` directly, with no proxy in the picture:
-
-```bash
-UNISSH__SERVER__BIND=0.0.0.0:8443
-UNISSH__SERVER__TLS_CERT=/certs/fullchain.pem
-UNISSH__SERVER__TLS_KEY=/certs/privkey.pem
-UNISSH__SERVER__TRUST_PROXY=false        # nothing in front; XFF must not be trusted
-```
-
-In Docker, mount the files and publish the port. The container runs as the distroless nonroot user, uid **65532**, so the key has to be readable by that uid — a root-owned `chmod 600` key (what a certbot copy leaves you with) makes the server exit at startup with:
-
-```
-Error: load TLS cert/key: failed to read from file `/certs/privkey.pem`: Permission denied (os error 13)
-```
-
-```bash
-sudo chown 65532:65532 certs/privkey.pem
-sudo chmod 600 certs/privkey.pem
-```
-
+**Use when** one admin runs one instance and wants the smallest possible deployment. The server has in-process rustls and can serve `/v1` directly.
 
 ```yaml
 services:
@@ -310,20 +272,27 @@ services:
       UNISSH__SERVER__BIND: "0.0.0.0:8443"
       UNISSH__SERVER__TLS_CERT: "/certs/fullchain.pem"
       UNISSH__SERVER__TLS_KEY: "/certs/privkey.pem"
-      UNISSH__SERVER__TRUST_PROXY: "false"
+      UNISSH__SERVER__TRUST_PROXY: "false"    # nothing in front; XFF is forgeable
 ```
+
+The container runs as the distroless nonroot user, so the key must be readable by **uid 65532**:
+
+```bash
+sudo chown 65532:65532 certs/privkey.pem
+```
+
+A root-owned `chmod 600` key — what a certbot copy leaves behind — makes the server exit at startup with `load TLS cert/key: … Permission denied (os error 13)`.
 
 Clients then use `https://host:8443`.
 
 :::caution[What you give up]
-There is **no admin panel** — the SPA is served by the front door, which no longer exists. Claim the instance and administer it from the desktop client instead. There is also no ACME (`acme = true` is a hard startup error), so renewal is entirely yours: replace the files and restart the container. Anything more than a single-admin instance is better served by scenario 2 or 3.
+**No admin panel** — it is served by the front door, which no longer exists; claim and administer the instance from the desktop client instead. **No ACME** either (`acme = true` is a hard startup error), so renewal is replace-the-files-and-restart. Anything beyond a single admin is better served by scenario 2 or 3.
 :::
 
-Setting `trust_proxy = false` matters here: with nothing in front, an `X-Forwarded-For` header can only have come from the client, so trusting it would let anyone forge their own IP and evade rate limiting.
+<details>
+<summary>Without Docker at all</summary>
 
-### Without Docker at all
-
-No server binaries are published — the release artifacts are the client apps and the two container images — so a bare-metal install means [building from source](../build/) (`cargo build --release -p unissh-server` → `target/release/unissh-server`) and running it under an init system. The config above applies unchanged, via `config.toml` or the same `UNISSH__*` environment keys:
+No server binaries are published — the release artifacts are the client apps and the two container images — so bare metal means [building from source](../build/) (`cargo build --release -p unissh-server`) and running it under an init system. Configuration is the same `config.toml` or `UNISSH__*` environment keys; a missing config file is fine, the environment alone is enough.
 
 ```ini
 # /etc/systemd/system/unissh-server.service
@@ -336,8 +305,8 @@ ExecStart=/usr/local/bin/unissh-server serve --config /etc/unissh/config.toml
 User=unissh
 Environment=UNISSH__SERVER__TLS_CERT=/etc/unissh/fullchain.pem
 Environment=UNISSH__SERVER__TLS_KEY=/etc/unissh/privkey.pem
+Environment=UNISSH__DB__URL=/var/lib/unissh/unissh.db
 Restart=on-failure
-# The key must be readable by User= and nothing else.
 NoNewPrivileges=true
 ProtectSystem=strict
 ProtectHome=true
@@ -348,48 +317,41 @@ StateDirectory=unissh
 WantedBy=multi-user.target
 ```
 
-Point `[db].url` at `/var/lib/unissh/unissh.db` (the `StateDirectory`), and remember there is no admin panel on this path either — the SPA needs a web server. Upgrades are yours to drive: rebuild, replace the binary, restart. The container images exist so that most operators don't have to.
+Create the user first (`sudo useradd -r -s /usr/sbin/nologin unissh`) and make the key readable by it. Upgrades are yours to drive: rebuild, replace the binary, restart. The container images exist so that most operators don't have to.
+
+</details>
 
 ---
 
-## Constraints worth knowing before you commit
+## Before you commit
 
-- **The site must live at the root of its hostname.** `https://unissh.example.com/` works; `https://example.com/unissh/` is not a tested layout. Give the instance its own hostname (or a subdomain) rather than a path on a shared one.
-- **A non-standard port is fine, everywhere except ACME.** `https://unissh.example.com:8443` works — clients accept the port, just set `UNISSH__SERVER__PUBLIC_URL` to match so invite links carry it. But Caddy's HTTP-01 challenge needs port 80 reachable, so on a host where 80 is taken, use [scenario 2](#scenario-2--caddy-with-certificates-you-already-have) or DNS-01 out of band.
-- **The panel is versioned with the server.** They ship as one image pair. Any layout that copies the SPA onto your own disk ([3b](#scenario-3b--the-proxy-replaces-caddy-one-hop)) has to re-copy it on every upgrade.
-- **One trusted hop.** The server assumes exactly one proxy between it and the client when it reads `X-Forwarded-For`. Two hops is supported and common ([3a](#scenario-3a--a-proxy-in-front-of-the-bundled-stack-recommended)), it just costs you per-client rate limiting.
-- **Whoever terminates TLS sees session tokens** — not vault contents, which are ciphertext end to end. Relevant when that terminator is someone else's infrastructure.
-- **Mobile clients need a publicly-rooted certificate.** A private CA is a desktop-only answer.
-- **What must be reachable:** 443 (and 80 only for ACME HTTP-01 and the redirect). The server's own port and the metrics port stay on the internal network in every scenario above; publishing them is never required.
+- **Give the instance its own hostname.** `https://unissh.example.com/` — a subpath like `https://example.com/unissh/` is not a tested layout.
+- **A non-standard port is fine** (`https://host:8443`); set `UNISSH__SERVER__PUBLIC_URL` to match so invite links carry it. ACME's HTTP-01 challenge still needs port 80, so where 80 is taken, use scenario 2.
+- **One trusted hop.** The server assumes a single proxy when it reads `X-Forwarded-For`. Two hops work and are common; they just cost per-client rate limiting.
+- **Only 443 has to be reachable** (plus 80 for ACME and the redirect). The server's own port and the metrics port stay internal in every scenario here.
+- **The panel is versioned with the server.** Any layout that copies it onto your disk has to re-copy it on upgrade.
 
 ## Troubleshooting
 
-**`refusing plaintext http:// to non-loopback host "…"`** — the client will not send bearer tokens in the clear. Serve HTTPS (any scenario above); there is no override.
-
-**`the server's TLS certificate is not trusted by this machine`** — the certificate chains to a CA this machine does not know: a self-signed/internal CA whose root is not installed ([scenario 4](#scenario-4--lan--air-gapped-self-signed-internal-ca)), or a chain served without its intermediates ([scenario 2](#scenario-2--caddy-with-certificates-you-already-have)). `curl -v https://<host>/readyz` from the same machine reproduces it without the app.
-
-**`certificate is not valid for this hostname`** — the certificate's names do not include the address you typed. Certificates for a bare IP are rare; issue for a hostname and use that hostname.
-
-**Caddy logs `"certutil" is not available`** — harmless, unrelated to client trust. See [scenario 4](#scenario-4--lan--air-gapped-self-signed-internal-ca).
-
-**Caddy cannot get an ACME certificate** — port 80 must be reachable from the internet for HTTP-01, and public DNS must resolve to this host. On a private network, use scenario 2 or 4 instead.
-
-**The admin panel loads but never unlocks** — the `.wasm` file is being served with the wrong content type. Check `curl -I https://<host>/assets/*.wasm | grep content-type`; it must be `application/wasm` ([scenario 3b](#scenario-3b--the-proxy-replaces-caddy-one-hop)).
-
-**A renewed certificate is still showing as the old one** — the file-based Caddy modes load the certificate once; `caddy reload --force` or a container restart is required after every renewal ([scenario 2](#scenario-2--caddy-with-certificates-you-already-have)).
-
-**The server exits with `Permission denied (os error 13)` on the key** — the key is not readable by uid 65532 in [scenario 5](#scenario-5--no-proxy-the-server-terminates-tls-itself). `chown 65532:65532` it.
-
-**Pushes fail with 413** — the proxy's body limit is below the server's `limits.max_body_bytes` (16 MiB default). Raise `client_max_body_size` (nginx) to match.
-
-**The panel shows an older version than the server** — a docroot copy of the SPA that was not refreshed after an upgrade ([3b](#scenario-3b--the-proxy-replaces-caddy-one-hop)). Re-copy `/srv` out of the current caddy image.
-
-**Everything 404s through your proxy** — the proxy is forwarding only `/v1` and not the SPA paths, or (in [3a](#scenario-3a--a-proxy-in-front-of-the-bundled-stack-recommended)) `UNISSH_DOMAIN` is still a hostname rather than `:80`, so the bundled Caddy is matching on a name your proxy doesn't send. Forward every path, and check `docker compose logs caddy`.
-
-**Rate limiting hits the wrong client** — either `trust_proxy` is true with nothing in front of the server, or the proxy is not appending the real peer to `X-Forwarded-For`. The server reads the rightmost element.
+| Symptom | Cause and fix |
+| --- | --- |
+| `refusing plaintext http:// to non-loopback host` | Working as designed — tokens ride that connection. Serve HTTPS; there is no override. |
+| `the server's TLS certificate is not trusted by this machine` | A private CA whose root is not installed ([4](#4--private-ca-lan--air-gapped)), or a chain served without its intermediates ([2](#2--your-own-certificate)). `curl -v https://<host>/readyz` reproduces it outside the app. |
+| `certificate is not valid for this hostname` | The certificate's names don't include the address you typed. Certificates for a bare IP are rare; issue for a hostname. |
+| A renewed certificate still shows as the old one | File-based certificates load once. `caddy reload --force` or restart ([2](#2--your-own-certificate)). |
+| Server exits with `Permission denied (os error 13)` on the key | The key is not readable by uid 65532 ([5](#5--no-proxy-at-all)). `chown 65532:65532`. |
+| Caddy logs `"certutil" is not available` | Harmless, and unrelated to client trust ([4](#4--private-ca-lan--air-gapped)). |
+| Caddy cannot get an ACME certificate | Port 80 must be reachable and public DNS must resolve here. On a private network use scenario 2 or 4. |
+| The panel loads but never unlocks | The `.wasm` file is served with the wrong content type. `curl -I …/assets/*.wasm` must show `application/wasm` ([3b](#3b--your-proxy-replaces-caddy)). |
+| The panel is a version behind the server | A docroot copy that wasn't refreshed after an upgrade ([3b](#3b--your-proxy-replaces-caddy)). |
+| Everything 404s through your proxy | The proxy forwards only `/v1`, or `UNISSH_DOMAIN` is still a hostname instead of `:80` in [3a](#3a--your-proxy-does-tls-only-start-here). Forward every path; check `docker compose logs caddy`. |
+| Pushes fail with 413 | The proxy's body limit is below `limits.max_body_bytes` (16 MiB). |
+| Rate limiting hits the wrong client | Either `trust_proxy` is true with nothing in front, or you are two hops deep ([3a](#3a--your-proxy-does-tls-only-start-here)). |
 
 ## See also
 
 - [Docker Compose deployment](../deploy/) — the full stack, profiles, first-run claim, backups.
-- [Server configuration](../configuration/) — every `config.toml` key and its env override.
+- [Server configuration](../configuration/) — every `config.toml` key and its environment override.
 - [Backups & anti-rollback restore](../backups/).
+
+<small>Every recipe on this page was run end to end against the published images, except the macOS and Windows trust-store commands, which are the vendor-documented ones.</small>

--- a/website/src/content/docs/operations/deploy-scenarios.md
+++ b/website/src/content/docs/operations/deploy-scenarios.md
@@ -243,8 +243,8 @@ The Linux paths are verified against a clean Debian and Fedora; the macOS and Wi
 curl -v https://unissh.local/readyz     # must succeed with NO -k
 ```
 
-:::note[`certutil is not available` in the Caddy log is a red herring]
-That is Caddy trying to install its root into the trust store **inside its own container**, where nothing consumes it. Installing `certutil` there fixes nothing and has no bearing on whether clients trust the certificate.
+:::note[If you see `certutil is not available` in the Caddy log]
+It is harmless and unrelated to client trust: Caddy was trying to install its root into the trust store **inside its own container**, where nothing consumes it. Installing `certutil` there fixes nothing. Newer images no longer attempt it (`skip_install_trust` in the shipped Caddyfile), so the line only appears on images built before that.
 :::
 
 :::caution[Mobile clients cannot use a private CA]
@@ -340,7 +340,7 @@ Create the user first (`sudo useradd -r -s /usr/sbin/nologin unissh`) and make t
 | `certificate is not valid for this hostname` | The certificate's names don't include the address you typed. Certificates for a bare IP are rare; issue for a hostname. |
 | A renewed certificate still shows as the old one | File-based certificates load once. `caddy reload --force` or restart ([2](#2--your-own-certificate)). |
 | Server exits with `Permission denied (os error 13)` on the key | The key is not readable by uid 65532 ([5](#5--no-proxy-at-all)). `chown 65532:65532`. |
-| Caddy logs `"certutil" is not available` | Harmless, and unrelated to client trust ([4](#4--private-ca-lan--air-gapped)). |
+| Caddy logs `"certutil" is not available` | Harmless, unrelated to client trust, and gone in current images ([4](#4--private-ca-lan--air-gapped)). |
 | Caddy cannot get an ACME certificate | Port 80 must be reachable and public DNS must resolve here. On a private network use scenario 2 or 4. |
 | The panel loads but never unlocks | The `.wasm` file is served with the wrong content type. `curl -I …/assets/*.wasm` must show `application/wasm` ([3b](#3b--your-proxy-replaces-caddy)). |
 | The panel is a version behind the server | A docroot copy that wasn't refreshed after an upgrade ([3b](#3b--your-proxy-replaces-caddy)). |

--- a/website/src/content/docs/operations/deploy-scenarios.md
+++ b/website/src/content/docs/operations/deploy-scenarios.md
@@ -237,7 +237,7 @@ sudo security add-trusted-cert -d -r trustRoot \
 Import-Certificate -FilePath unissh-root.crt -CertStoreLocation Cert:\LocalMachine\Root
 ```
 
-Confirm from the client before opening the app — `curl` reads the same store:
+The Linux paths are verified against a clean Debian and Fedora; the macOS and Windows lines are the vendor-documented ones. Confirm from the client before opening the app — `curl` reads the same store:
 
 ```bash
 curl -v https://unissh.local/readyz     # must succeed with NO -k
@@ -353,5 +353,3 @@ Create the user first (`sudo useradd -r -s /usr/sbin/nologin unissh`) and make t
 - [Docker Compose deployment](../deploy/) — the full stack, profiles, first-run claim, backups.
 - [Server configuration](../configuration/) — every `config.toml` key and its environment override.
 - [Backups & anti-rollback restore](../backups/).
-
-<small>Every recipe on this page was run end to end against the published images, except the macOS and Windows trust-store commands, which are the vendor-documented ones.</small>

--- a/website/src/content/docs/operations/deploy-scenarios.md
+++ b/website/src/content/docs/operations/deploy-scenarios.md
@@ -1,0 +1,260 @@
+---
+title: Deployment scenarios
+description: Four ways to put TLS in front of a self-hosted UniSSH server — Caddy with automatic ACME, Caddy with certificates you already have, your own nginx, and a LAN deployment behind a self-signed internal CA.
+---
+
+The [Docker Compose deployment](../deploy/) ships one opinionated path: Caddy in front, a certificate from Let's Encrypt, the admin panel and the API on one origin. This page covers the other four situations operators actually land in — an existing certificate, an existing nginx, no proxy at all, and a LAN with no public DNS.
+
+Everything below changes **only the front door**. The UniSSH server itself is unchanged: plain HTTP on an internal network, `trust_proxy = true`, no ACME (`acme = true` is a hard startup error). Whatever terminates TLS is the only piece that differs.
+
+## What the client requires
+
+Before picking a scenario, know the two rules the desktop and mobile clients enforce. They are what make a "quick" deployment fail later.
+
+1. **The server URL must be `https://`.** Plain `http://` is accepted only for loopback (`localhost`, `127.x`, `[::1]`) — the connection carries bearer tokens, so a plaintext hop to a real host would hand an on-path attacker a working session. The client fails with:
+
+   ```
+   refusing plaintext http:// to non-loopback host "10.0.0.5:8443":
+   use https:// so tokens and data are encrypted in transit
+   ```
+
+   This is not a setting. There is no flag to turn it off.
+
+2. **The certificate must verify against the machine's OS trust store.** The client uses the platform verifier — the same roots your browser and `curl` use on that machine — and offers no "continue anyway" prompt. A public CA works out of the box; a private or self-signed CA works once its **root** is installed on each client machine ([scenario 4](#scenario-4--lan--air-gapped-self-signed-internal-ca)).
+
+Everything else — port, path, hostname — is yours to choose.
+
+## Pick a scenario
+
+| Your situation | Scenario | TLS lives in |
+| --- | --- | --- |
+| Public DNS name, want certificates handled for you | [1 — Caddy + ACME](#scenario-1--caddy--automatic-acme-default) | Caddy (automatic) |
+| You already hold a certificate (corporate CA, wildcard, DNS-01, certbot) | [2 — Caddy + your files](#scenario-2--caddy-with-certificates-you-already-have) | Caddy (files) |
+| nginx already runs on this host and terminates TLS | [3 — your own nginx](#scenario-3--your-own-nginx-in-front) | nginx |
+| No public DNS at all: LAN, air-gapped, IP-only | [4 — self-signed internal CA](#scenario-4--lan--air-gapped-self-signed-internal-ca) | Caddy (internal CA) |
+| No proxy wanted; API only, no admin panel | [5 — the server terminates TLS](#scenario-5--no-proxy-the-server-terminates-tls-itself) | the server (rustls) |
+
+Scenarios 1, 2 and 4 keep the bundled Caddy and differ by one line in `.env`. Scenarios 3 and 5 replace the front door.
+
+---
+
+## Scenario 1 — Caddy + automatic ACME (default)
+
+The shipped path, covered in full on the [Docker Compose deployment](../deploy/) page. `.env`:
+
+```bash
+UNISSH_DOMAIN=unissh.example.com
+UNISSH_TLS_DIRECTIVE=tls you@example.com    # empty is also valid (no expiry notices)
+```
+
+Requires public DNS pointing at the host and port **80** reachable for the challenge and the HTTP→HTTPS redirect. Renewal is automatic and needs no operator action.
+
+---
+
+## Scenario 2 — Caddy with certificates you already have
+
+For a certificate that does not come from Caddy's own ACME: a corporate/internal CA, a commercial wildcard, a DNS-01 issuance, or a cert renewed on the host by certbot/acme.sh. Caddy still serves the SPA and proxies the API — only where the certificate comes from changes.
+
+**1. Put the two files on the host.** Default location is `./certs` at the repository root:
+
+```bash
+mkdir -p certs
+cp /path/to/fullchain.pem certs/fullchain.pem   # leaf FIRST, then intermediates
+cp /path/to/privkey.pem   certs/privkey.pem     # unencrypted PEM
+chmod 600 certs/privkey.pem
+```
+
+:::caution[Ship the full chain, not just the leaf]
+A leaf-only `cert.pem` frequently works in a browser (which caches intermediates from other sites) and then fails in the UniSSH client, which does not. If in doubt, check with
+`openssl s_client -connect host:443 -showcerts </dev/null` — you should see the leaf **and** every intermediate up to a root your machine trusts.
+:::
+
+**2. Point the TLS knob at them** in `.env`:
+
+```bash
+UNISSH_DOMAIN=unissh.example.com
+UNISSH_TLS_DIRECTIVE=tls /certs/fullchain.pem /certs/privkey.pem
+# UNISSH_CERTS_DIR=./certs        # optional: mount some other host directory
+```
+
+**3. Start with the cert-mount override** (`deploy/compose.tls-files.yml`, which bind-mounts that directory read-only at `/certs`):
+
+```bash
+docker compose -f compose.prod.yml -f deploy/compose.tls-files.yml up -d
+# or, building from source:
+docker compose -f compose.yml -f deploy/compose.tls-files.yml up -d --build
+```
+
+Relative host paths in the override resolve against the **first** `-f` file's directory (the repository root), which is why the default is `./certs` and not `../certs`.
+
+**Renewal.** Caddy watches the files: rewrite `fullchain.pem` / `privkey.pem` in place and it picks up the new certificate without a restart. A certbot deploy hook only has to `cp` the files — no `docker compose` command is needed.
+
+---
+
+## Scenario 3 — your own nginx in front
+
+For hosts where nginx already terminates TLS for other sites. The job is the same one Caddy does: **terminate TLS, serve the admin SPA from disk, reverse-proxy the API to the server.**
+
+```
+client ──TLS──► nginx ──plain HTTP──► 127.0.0.1:8443 (unissh-server)
+                  └─ SPA from /var/www/unissh
+```
+
+**1. Start the stack without the bundled Caddy.** The `deploy/compose.reverse-proxy.yml` override parks Caddy behind a profile nobody enables (so ports 80/443 stay free) and publishes the API on loopback only:
+
+```bash
+docker compose -f compose.prod.yml -f deploy/compose.reverse-proxy.yml up -d
+curl -i http://127.0.0.1:8443/readyz     # HTTP/1.1 200 OK (empty body)
+```
+
+**2. Put the admin SPA on disk.** Its files live inside the caddy image at `/srv`; copy them out once per upgrade:
+
+```bash
+cid=$(docker create ghcr.io/goduni/unissh-caddy:latest)
+sudo mkdir -p /var/www/unissh
+sudo docker cp "$cid:/srv/." /var/www/unissh/
+docker rm "$cid"
+```
+
+(Or build them yourself — the panel needs its wasm package built first: `just build-wasm && cd server-ui && npm ci && npm run build` → `dist/`. See [Build from source](../build/).)
+
+**3. Install the server block.** [`deploy/nginx/unissh.conf`](https://github.com/goduni/unissh/blob/main/deploy/nginx/unissh.conf) is a complete, tested one — copy it to `/etc/nginx/conf.d/`, edit `server_name` and the two `ssl_certificate` paths, then `nginx -t && systemctl reload nginx`.
+
+Four details in it are load-bearing, whichever proxy you actually use:
+
+- **Same origin for SPA and API.** The panel calls the API with a relative base, so serving both from one hostname is what keeps CORS off server-side. Splitting them across two names means enabling `cors_allowed_origins` and weakening the CSP.
+- **`application/wasm`.** The panel's crypto module is loaded with `WebAssembly.instantiateStreaming`, which rejects any other content type. Older `mime.types` files have no `wasm` entry, and the only symptom is a panel that never unlocks.
+- **`client_max_body_size 16m`.** It must be at least the server's `limits.max_body_bytes` (16 MiB by default) or nginx returns 413 for a legal push before the server sees it.
+- **`X-Forwarded-For`.** With `trust_proxy = true` the server reads the **rightmost** element as the client IP for per-IP rate limiting. nginx's `$proxy_add_x_forwarded_for` appends the real peer on the right, so a client-supplied header cannot displace it. A proxy that *overwrites* XFF with a client-controlled value would hand every user a way past the rate limit.
+
+**If your proxy runs in a container**, drop the `ports:` block from the override, attach the proxy to the `unissh` network, and forward to `http://server:8443` by service name — then nothing is host-published at all.
+
+**Invite links.** Nothing derives your public address for you; set it so invites come back with a usable URL:
+
+```bash
+UNISSH__SERVER__PUBLIC_URL=https://unissh.example.com
+```
+
+The same recipe transfers to HAProxy, Traefik or an appliance: TLS in front, one origin, correct `X-Forwarded-For`, a body limit ≥ 16 MiB, `application/wasm` for the SPA.
+
+---
+
+## Scenario 4 — LAN / air-gapped (self-signed internal CA)
+
+No public DNS means no ACME. Caddy can issue from its own internal CA:
+
+```bash
+UNISSH_DOMAIN=unissh.local          # or an IP: 10.0.0.5
+UNISSH_TLS_DIRECTIVE=tls internal
+```
+
+This works — but it is only half the job, and skipping the other half is the single most common failed self-hosted deployment. **Every client machine must trust that CA root.** The client verifies against the OS trust store and has no "accept anyway" prompt, and (per [What the client requires](#what-the-client-requires)) falling back to `http://` is refused.
+
+:::note[The `certutil` warning in the Caddy log is a red herring]
+```
+warning: "certutil" is not available, install "certutil" with "apt install libnss3-tools" …
+```
+That is Caddy trying to install its root into the trust store **inside its own container**, where nothing consumes it. It is harmless, installing `certutil` there fixes nothing, and it is unrelated to whether clients trust the certificate.
+:::
+
+**Export the root** (once — it lives in the `caddy-data` volume, which is why that volume must persist):
+
+```bash
+docker compose cp caddy:/data/caddy/pki/authorities/local/root.crt ./unissh-root.crt
+```
+
+**Install it on every client machine:**
+
+```bash
+# Debian / Ubuntu
+sudo cp unissh-root.crt /usr/local/share/ca-certificates/unissh-root.crt
+sudo update-ca-certificates
+
+# Fedora / RHEL
+sudo cp unissh-root.crt /etc/pki/ca-trust/source/anchors/
+sudo update-ca-trust
+
+# macOS
+sudo security add-trusted-cert -d -r trustRoot \
+  -k /Library/Keychains/System.keychain unissh-root.crt
+
+# Windows (elevated PowerShell)
+Import-Certificate -FilePath unissh-root.crt -CertStoreLocation Cert:\LocalMachine\Root
+```
+
+Verify from a client before opening the app — `curl` uses the same store:
+
+```bash
+curl -v https://unissh.local/readyz     # must succeed with NO -k
+```
+
+:::caution[Mobile clients cannot use a private CA]
+Android does not let apps trust user-installed CAs by default, and iOS requires the profile to be installed *and* enabled under Certificate Trust Settings. If phones or tablets are part of the plan, do not rely on an internal CA — get a real certificate for a real name (a public CA with DNS-01 works fine for a host that is not reachable from the internet) and use [scenario 2](#scenario-2--caddy-with-certificates-you-already-have).
+:::
+
+If the CA root cannot be distributed at all, the remaining supported option is **loopback**: reach the server through an SSH tunnel and point the client at `http://127.0.0.1:<port>` — loopback plaintext is allowed precisely because it never touches a network.
+
+---
+
+## Scenario 5 — no proxy: the server terminates TLS itself
+
+The smallest possible deployment. The server has in-process rustls; give it a certificate and key and it serves `/v1` directly, with no proxy in the picture:
+
+```bash
+UNISSH__SERVER__BIND=0.0.0.0:8443
+UNISSH__SERVER__TLS_CERT=/certs/fullchain.pem
+UNISSH__SERVER__TLS_KEY=/certs/privkey.pem
+UNISSH__SERVER__TRUST_PROXY=false        # nothing in front; XFF must not be trusted
+```
+
+In Docker, mount the files and publish the port (the container runs as the distroless nonroot user, uid **65532** — the key must be readable by it):
+
+```yaml
+services:
+  server:
+    image: ghcr.io/goduni/unissh-server:latest
+    ports:
+      - "8443:8443"
+    volumes:
+      - unissh-data:/app/data
+      - ./certs:/certs:ro
+    environment:
+      UNISSH__SERVER__BIND: "0.0.0.0:8443"
+      UNISSH__SERVER__TLS_CERT: "/certs/fullchain.pem"
+      UNISSH__SERVER__TLS_KEY: "/certs/privkey.pem"
+      UNISSH__SERVER__TRUST_PROXY: "false"
+```
+
+Clients then use `https://host:8443`.
+
+:::caution[What you give up]
+There is **no admin panel** — the SPA is served by the front door, which no longer exists. Claim the instance and administer it from the desktop client instead. There is also no ACME (`acme = true` is a hard startup error), so renewal is entirely yours: replace the files and restart the container. Anything more than a single-admin instance is better served by scenario 2 or 3.
+:::
+
+Setting `trust_proxy = false` matters here: with nothing in front, an `X-Forwarded-For` header can only have come from the client, so trusting it would let anyone forge their own IP and evade rate limiting.
+
+---
+
+## Troubleshooting
+
+**`refusing plaintext http:// to non-loopback host "…"`** — the client will not send bearer tokens in the clear. Serve HTTPS (any scenario above); there is no override.
+
+**`the server's TLS certificate is not trusted by this machine`** — the certificate chains to a CA this machine does not know: a self-signed/internal CA whose root is not installed ([scenario 4](#scenario-4--lan--air-gapped-self-signed-internal-ca)), or a chain served without its intermediates ([scenario 2](#scenario-2--caddy-with-certificates-you-already-have)). `curl -v https://<host>/readyz` from the same machine reproduces it without the app.
+
+**`certificate is not valid for this hostname`** — the certificate's names do not include the address you typed. Certificates for a bare IP are rare; issue for a hostname and use that hostname.
+
+**Caddy logs `"certutil" is not available`** — harmless, unrelated to client trust. See [scenario 4](#scenario-4--lan--air-gapped-self-signed-internal-ca).
+
+**Caddy cannot get an ACME certificate** — port 80 must be reachable from the internet for HTTP-01, and public DNS must resolve to this host. On a private network, use scenario 2 or 4 instead.
+
+**The admin panel loads but never unlocks** — the `.wasm` file is being served with the wrong content type. Check `curl -I https://<host>/assets/*.wasm | grep content-type`; it must be `application/wasm` ([scenario 3](#scenario-3--your-own-nginx-in-front)).
+
+**Pushes fail with 413** — the proxy's body limit is below the server's `limits.max_body_bytes` (16 MiB default). Raise `client_max_body_size` (nginx) to match.
+
+**Rate limiting hits the wrong client** — either `trust_proxy` is true with nothing in front of the server, or the proxy is not appending the real peer to `X-Forwarded-For`. The server reads the rightmost element.
+
+## See also
+
+- [Docker Compose deployment](../deploy/) — the full stack, profiles, first-run claim, backups.
+- [Server configuration](../configuration/) — every `config.toml` key and its env override.
+- [Backups & anti-rollback restore](../backups/).

--- a/website/src/content/docs/operations/deploy-scenarios.md
+++ b/website/src/content/docs/operations/deploy-scenarios.md
@@ -91,7 +91,16 @@ docker compose -f compose.yml -f deploy/compose.tls-files.yml up -d --build
 
 Relative host paths in the override resolve against the **first** `-f` file's directory (the repository root), which is why the default is `./certs` and not `../certs`.
 
-**Renewal.** Caddy watches the files: rewrite `fullchain.pem` / `privkey.pem` in place and it picks up the new certificate without a restart. A certbot deploy hook only has to `cp` the files — no `docker compose` command is needed.
+:::danger[Renewal does not happen by itself]
+Caddy loads these files **once**. Rewriting them on disk changes nothing — the old certificate keeps being served, and plain `caddy reload` is a no-op because the config is unchanged. (Both verified against a running container: after swapping the files, the original certificate was still on the wire.) Every renewal must be followed by:
+
+```bash
+docker compose exec caddy caddy reload --force --config /etc/caddy/Caddyfile
+# or: docker compose restart caddy
+```
+
+Put that in the certbot/acme.sh **deploy hook**. Otherwise the instance serves an expired certificate — and because the client has no "accept anyway", that is a full outage, not a warning.
+:::
 
 ---
 
@@ -276,7 +285,17 @@ UNISSH__SERVER__TLS_KEY=/certs/privkey.pem
 UNISSH__SERVER__TRUST_PROXY=false        # nothing in front; XFF must not be trusted
 ```
 
-In Docker, mount the files and publish the port (the container runs as the distroless nonroot user, uid **65532** — the key must be readable by it):
+In Docker, mount the files and publish the port. The container runs as the distroless nonroot user, uid **65532**, so the key has to be readable by that uid — a root-owned `chmod 600` key (what a certbot copy leaves you with) makes the server exit at startup with:
+
+```
+Error: load TLS cert/key: failed to read from file `/certs/privkey.pem`: Permission denied (os error 13)
+```
+
+```bash
+sudo chown 65532:65532 certs/privkey.pem
+sudo chmod 600 certs/privkey.pem
+```
+
 
 ```yaml
 services:
@@ -356,6 +375,10 @@ Point `[db].url` at `/var/lib/unissh/unissh.db` (the `StateDirectory`), and reme
 **Caddy cannot get an ACME certificate** — port 80 must be reachable from the internet for HTTP-01, and public DNS must resolve to this host. On a private network, use scenario 2 or 4 instead.
 
 **The admin panel loads but never unlocks** — the `.wasm` file is being served with the wrong content type. Check `curl -I https://<host>/assets/*.wasm | grep content-type`; it must be `application/wasm` ([scenario 3b](#scenario-3b--the-proxy-replaces-caddy-one-hop)).
+
+**A renewed certificate is still showing as the old one** — the file-based Caddy modes load the certificate once; `caddy reload --force` or a container restart is required after every renewal ([scenario 2](#scenario-2--caddy-with-certificates-you-already-have)).
+
+**The server exits with `Permission denied (os error 13)` on the key** — the key is not readable by uid 65532 in [scenario 5](#scenario-5--no-proxy-the-server-terminates-tls-itself). `chown 65532:65532` it.
 
 **Pushes fail with 413** — the proxy's body limit is below the server's `limits.max_body_bytes` (16 MiB default). Raise `client_max_body_size` (nginx) to match.
 

--- a/website/src/content/docs/operations/deploy.md
+++ b/website/src/content/docs/operations/deploy.md
@@ -56,7 +56,7 @@ Caddy is the **only** TLS terminator and the only host-exposed service. The UniS
 TLS is controlled by one env knob, `UNISSH_TLS_DIRECTIVE`:
 
 - **Public domain (automatic ACME):** set `UNISSH_DOMAIN` to your real domain and `UNISSH_TLS_DIRECTIVE="tls you@example.com"` (the email enables expiry notices; leave it empty for ACME without an account email). Caddy gets a public cert (Let's Encrypt / ZeroSSL via HTTP-01 or TLS-ALPN-01). Port 80 must be reachable for the challenge and the HTTP→HTTPS redirect.
-- **Certificates you already have:** set `UNISSH_TLS_DIRECTIVE="tls /certs/fullchain.pem /certs/privkey.pem"` and mount them with the `deploy/compose.tls-files.yml` override. Caddy reloads the files in place on renewal.
+- **Certificates you already have:** set `UNISSH_TLS_DIRECTIVE="tls /certs/fullchain.pem /certs/privkey.pem"` and mount them with the `deploy/compose.tls-files.yml` override. Renewal needs an explicit `caddy reload --force` — see [Deployment scenarios](../deploy-scenarios/).
 - **LAN / air-gapped (self-signed internal CA):** set `UNISSH_DOMAIN` to a local host (e.g. `unissh.local`) or an IP and `UNISSH_TLS_DIRECTIVE="tls internal"`. Caddy issues a cert from its own internal CA — every client machine must then **trust that root** (export it from the `caddy-data` volume at `/data/caddy/pki/authorities/local/root.crt`). The client verifies against the OS trust store and has no "accept anyway" prompt, and it refuses plain `http://` to a non-loopback host.
 
 For certificates you already hold, an existing nginx in front, a LAN with no public DNS, or no proxy at all, see **[Deployment scenarios](../deploy-scenarios/)** — with a tested nginx server block and the client-side trust steps.

--- a/website/src/content/docs/operations/deploy.md
+++ b/website/src/content/docs/operations/deploy.md
@@ -56,7 +56,10 @@ Caddy is the **only** TLS terminator and the only host-exposed service. The UniS
 TLS is controlled by one env knob, `UNISSH_TLS_DIRECTIVE`:
 
 - **Public domain (automatic ACME):** set `UNISSH_DOMAIN` to your real domain and `UNISSH_TLS_DIRECTIVE="tls you@example.com"` (the email enables expiry notices; leave it empty for ACME without an account email). Caddy gets a public cert (Let's Encrypt / ZeroSSL via HTTP-01 or TLS-ALPN-01). Port 80 must be reachable for the challenge and the HTTP→HTTPS redirect.
-- **LAN / air-gapped (self-signed internal CA):** set `UNISSH_DOMAIN` to a local host (e.g. `unissh.local`) or an IP and `UNISSH_TLS_DIRECTIVE="tls internal"`. Caddy issues a cert from its own internal CA — trust Caddy's root CA on clients (export it from the `caddy-data` volume at `/data/caddy/pki/authorities/local/root.crt`) or accept the self-signed cert.
+- **Certificates you already have:** set `UNISSH_TLS_DIRECTIVE="tls /certs/fullchain.pem /certs/privkey.pem"` and mount them with the `deploy/compose.tls-files.yml` override. Caddy reloads the files in place on renewal.
+- **LAN / air-gapped (self-signed internal CA):** set `UNISSH_DOMAIN` to a local host (e.g. `unissh.local`) or an IP and `UNISSH_TLS_DIRECTIVE="tls internal"`. Caddy issues a cert from its own internal CA — every client machine must then **trust that root** (export it from the `caddy-data` volume at `/data/caddy/pki/authorities/local/root.crt`). The client verifies against the OS trust store and has no "accept anyway" prompt, and it refuses plain `http://` to a non-loopback host.
+
+For certificates you already hold, an existing nginx in front, a LAN with no public DNS, or no proxy at all, see **[Deployment scenarios](../deploy-scenarios/)** — with a tested nginx server block and the client-side trust steps.
 
 :::tip[Keep the `caddy-data` volume]
 The `caddy-data` volume persists issued certs and the internal CA root. Keep it.


### PR DESCRIPTION
Closes #28.

The compose stack documented exactly one front door — Caddy with automatic ACME. Everything else an operator might already have (a certificate, an nginx, a LAN with no public DNS) had to be reverse-engineered from the Caddyfile.

Reported separately by **@cidious** in the community DMs: bringing the server up with `tls internal` logs

```
warning: "certutil" is not available, install "certutil" with "apt install libnss3-tools" …
```

and then the client refuses the fallback:

```
refusing plaintext http:// to non-loopback host "x.x.x.x:yyy":
use https:// so tokens and data are encrypted in transit
```

Both are working as intended, and neither said so. The `certutil` line is Caddy trying to trust its root **inside its own container**, where nothing consumes it — irrelevant to clients, and installing certutil there fixes nothing. The `http://` refusal is deliberate: the connection carries bearer tokens. The missing piece was never a bug in either — it was that nobody wrote down the actual step, which is to install Caddy's internal CA root into the trust store of each **client** machine. The client verifies via the OS platform verifier, so a private CA works fine once its root is there.

## Docs

New **Deployment scenarios** page (`website/src/content/docs/operations/deploy-scenarios.md`):

1. Caddy + automatic ACME (the existing default)
2. **Caddy with certificates you already have** — corporate CA, wildcard, DNS-01, certbot on the host
3. **A proxy you already run** — three sub-scenarios: (3a) TLS-only proxy in front of the bundled stack, (3b) the proxy replaces Caddy entirely, (3c) Traefik by labels
4. **LAN / air-gapped internal CA** — export the root, per-OS install commands, `curl` verification, and the mobile caveat (Android won't trust user CAs from an app; iOS needs the profile enabled)
5. **No proxy at all** — the server terminates TLS itself with in-process rustls, API only, no admin panel

Plus a "what the client requires" preamble (https, OS-trusted chain) and troubleshooting keyed to the exact strings users hit, both of @cidious's included.

plus a CDN/WAF/tunnel section (Cloudflare and friends) and a "constraints worth knowing before you commit" list.

## Shipped configs, not snippets

- `deploy/compose.tls-files.yml` — mounts your cert directory read-only into Caddy; `UNISSH_TLS_DIRECTIVE="tls /certs/fullchain.pem /certs/privkey.pem"`. Caddy reloads renewed files in place, so a certbot hook only has to `cp`.
- `deploy/compose.behind-proxy.yml` — **the recommended way to front the stack.** Setting Caddy's site address to `:80` turns it into a plain-HTTP internal front (SPA + API proxy, no ACME, no internal CA) on `127.0.0.1:8080`. Your proxy just terminates TLS and forwards everything, and the panel keeps travelling with the image — nothing to re-sync on upgrade.
- `deploy/compose.traefik.yml` — the same, published through an existing Traefik by labels over a shared network; nothing host-published.
- `deploy/compose.reverse-proxy.yml` — no bundled Caddy at all; publishes the API on `127.0.0.1:8443` for a proxy that will also serve the SPA.
- `deploy/nginx/unissh.conf` — TLS + one `proxy_pass` (pairs with `compose.behind-proxy.yml`).
- `deploy/nginx/unissh-static-spa.conf` — nginx doing the Caddyfile's whole job (pairs with `compose.reverse-proxy.yml`). One hop, so the server sees real client IPs.

Every override was checked with `docker compose config` (volume merge, relative paths resolving to the repo root, `!override` actually replacing the 80/443 mappings instead of appending, caddy dropped from the service list).

Both proxy chains were then run for real — nginx → caddy → stub server, and Traefik → caddy → stub server — and the SPA, deep links, the API and the stack's security headers all survive the extra hop.

**The one downside is documented rather than left to be discovered:** the server reads the *rightmost* `X-Forwarded-For` element, and Caddy — trusting no upstream — replaces the header with its own peer, so with two hops per-IP rate limiting becomes instance-wide. Setting `trusted_proxies static private_ranges` does **not** fix it (I tested: the chain is preserved, but the rightmost element is still the inner proxy), so the answer is the one-hop layout or a higher limit. The default Caddyfile is left alone.

The static-SPA nginx block was likewise run against a live nginx, which is where four of its details came from:

- `X-Forwarded-For` — the server reads the **rightmost** element; `$proxy_add_x_forwarded_for` appends the real peer, so a client-supplied header can't displace it and evade the per-IP rate limit (verified: a spoofed XFF lands left of the real peer)
- `application/wasm` — absent from older `mime.types`, and the panel's `WebAssembly.instantiateStreaming` rejects anything else; the only symptom is a panel that never unlocks
- `client_max_body_size 16m` — must be ≥ `limits.max_body_bytes`, or a legal push is 413'd before the server sees it
- `Cache-Control` via a `map` rather than per-location `add_header` — an `add_header` inside a location drops **every** inherited header, which would have quietly stripped the CSP from the assets

Also threads `UNISSH__SERVER__PUBLIC_URL` through both compose files: nothing derives the public address, so without it invites come back with no URL.

## Gaps closed in the second pass

Asked whether the scenarios were actually complete enough for wide use, I went looking for what was missing:

- **DNS-01 is not available in the shipped Caddy image** — those challenges need a provider plugin compiled in with `xcaddy`. The page previously implied you could just use it. Now it says: get the certificate out of band, then scenario 2.
- **No published server binaries**, so bare metal means building from source — added, with a systemd unit.
- **Whoever terminates TLS sees session tokens** (never vault contents, which stay ciphertext) — worth stating explicitly before someone puts this behind a third party.
- **Root-of-hostname only**; non-standard ports fine except for HTTP-01; what must actually be reachable.
- Upgrade skew for the docroot layout, and two more troubleshooting entries.

## The `certutil` warning itself

Nothing was ever broken by it, but it is now suppressed rather than only explained: `skip_install_trust` in the shipped Caddyfile stops Caddy from trying to install its internal CA root into its own container's trust store, where nothing reads it. Verified against the published image — warning gone, certificate still issued, root still exportable, ACME and file modes unaffected (they never installed anything locally). The docs keep the explanation for images built before this.

## Client

`transport_err` now appends an instruction to a TLS verification failure instead of surfacing rustls' verdict alone — where to put the CA root for an untrusted issuer, and distinct messages for a hostname mismatch and an expired certificate. Non-TLS transport errors are untouched. The verdict lives several `source()`s below the request error, so the match runs over the flattened chain.

No behavioural change: `https://` is still required, there is still no "accept anyway", and no in-app custom-CA setting was added — the OS trust store already is that mechanism on desktop, and on mobile a real certificate is the answer.

## What was actually run (and what wasn't)

Verified against the published images, not asserted:

- **Certificate files in Caddy** — SPA served over the mounted cert, correct subject on the wire.
- **`tls internal`** — cert issued on demand, `root.crt` exactly at the documented path, and @cidious's `certutil` warning reproduced.
- **The client-trust steps, end to end** — from a clean Debian container, `curl` rejects the internal-CA host (exit 60); after `cp` + `update-ca-certificates` it returns 200 with no `-k`. That is the same store rustls' platform verifier reads, which is why the desktop client works once the root is installed.
- **The server terminating TLS itself** — `rustls TLS 1.3`, `/readyz` 200, `/v1/instance` answering.
- **nginx → caddy → server** and **Traefik → caddy → server** — SPA, deep links, API, security headers.
- **The whole recommended stack** in an isolated compose project (real server image): SPA, `/readyz` 200 with an empty body, `/v1/instance`, and the documented setup-code grep finding the code.

Two documented claims were **disproved by running them**, and are fixed in the last commit:

- File-based certificates do **not** hot-reload. The old certificate was still being served 75s after the files were swapped, and plain `caddy reload` is a no-op. Only `caddy reload --force` or a restart picks it up — so the previous "just `cp` the files, no docker command needed" would have walked operators into an expired cert, which with no "accept anyway" in the client is an outage.
- A root-owned `chmod 600` key makes the server exit with `Permission denied (os error 13)`; the no-proxy scenario now hands over the `chown 65532:65532`.

Closed afterwards, so the untested set is now down to two items:

- **Fedora trust path** — run end to end too (curl exit 60 → 200 after `update-ca-trust`).
- **The systemd unit** — passes `systemd-analyze verify` with no warnings, and a missing `config.toml` was confirmed harmless (figment skips it), so the unit can rely on environment keys alone.
- **macOS / Windows trust commands** — not executable here; corroborated against vendor documentation. The page says outright that these two are the only recipes on it that were not run.

## Readability

The last commit reorganises the page around the question people arrive with: a five-row chooser at the top, one heading per situation, and a fixed shape inside each — *use when*, the commands, then the one thing that bites. The two client-side rules that decide whether any of it works are stated once up front. Reference material worth having but not worth reading twice (the nginx invariants, the systemd unit) sits in `<details>`, and troubleshooting is now a symptom → cause table. Same content, 40 lines shorter.
