### PR TITLE
fix(terminal): stop the contrast pass eating pasted text

### DIFF
--- a/client/src/theme/termPrefs.test.ts
+++ b/client/src/theme/termPrefs.test.ts
@@ -31,7 +31,10 @@ describe("termOptions", () => {
     expect(o.letterSpacing).toBe(0);
     expect(o.cursorBlink).toBe(true);
     expect(o.cursorStyle).toBe("block");
-    expect(o.minimumContrastRatio).toBe(1.1);
+    // Exactly 1 — xterm's sentinel for "leave colours alone". Anything above it
+    // turns on the per-cell contrast pass, which mis-renders inverse-video runs
+    // (a shell's bracketed-paste highlight) as text on same-coloured text (#38).
+    expect(o.minimumContrastRatio).toBe(1);
     expect(o.drawBoldTextInBrightColors).toBe(true);
     expect(o.macOptionClickForcesSelection).toBe(true);
   });

--- a/client/src/theme/tokens.ts
+++ b/client/src/theme/tokens.ts
@@ -711,7 +711,9 @@ export function termOptions(prefs: TermPrefs, theme: TermTheme, fontSize: number
     // runs (how shells highlight a bracketed paste) as text on text of the same
     // colour (#38). ANSI black already gets its own lifted tone in termToXterm,
     // which is where that concern actually belongs. Raising the floor stays an
-    // explicit accessibility choice.
+    // explicit accessibility choice — with the caveat that turning it on brings
+    // the #38 rendering back for inverse-video runs (white on the inverted
+    // background there). That half is xterm's bug to fix, not ours.
     minimumContrastRatio: prefs.minContrast ? 4.5 : 1,
     allowProposedApi: true,
     // When a TUI turns on mouse reporting, a plain drag no longer selects text. macOS

--- a/client/src/theme/tokens.ts
+++ b/client/src/theme/tokens.ts
@@ -703,10 +703,16 @@ export function termOptions(prefs: TermPrefs, theme: TermTheme, fontSize: number
     cursorBlink: prefs.cursorBlink,
     scrollback: prefs.scrollback,
     theme: prefs.fg ? { ...base, foreground: prefs.fg, cursor: prefs.fg } : base,
-    // Render bold text in the (distinct) bright palette and nudge any too-low-contrast
-    // glyph so nothing comes out unreadable.
+    // Render bold text in the (distinct) bright palette.
     drawBoldTextInBrightColors: true,
-    minimumContrastRatio: prefs.minContrast ? 4.5 : 1.1,
+    // 1 is xterm's "off". The old 1.1 default was a safety net against fg==bg
+    // text, but it never delivered one — it lifted such a glyph to ~1.3:1, still
+    // invisible — while switching on a contrast pass that renders inverse-video
+    // runs (how shells highlight a bracketed paste) as text on text of the same
+    // colour (#38). ANSI black already gets its own lifted tone in termToXterm,
+    // which is where that concern actually belongs. Raising the floor stays an
+    // explicit accessibility choice.
+    minimumContrastRatio: prefs.minContrast ? 4.5 : 1,
     allowProposedApi: true,
     // When a TUI turns on mouse reporting, a plain drag no longer selects text. macOS
     // needs this flag for the Option+drag override (Shift works elsewhere by default).


### PR DESCRIPTION
Closes #38.

Reported by **@foreignerby** on macOS: text pasted into a pane is drawn in almost the colour of its own highlight and stays unreadable until an arrow key or the next keystroke redraws the line. Independent of the selected theme.

## Root cause

zsh marks a bracketed paste with `standout`, i.e. an inverse-video run. In xterm.js's **DOM** renderer, a default-coloured inverse cell resolves its background to `theme.foreground` — but the minimum-contrast call is handed `theme.foreground` as the *foreground* too (`DomRendererRowFactory`, the `CM_DEFAULT` branch). That is a colour against itself, contrast 1.0. With `minimumContrastRatio` above 1, xterm "corrects" the pair and reports success, so `xterm-fg-INVERTED_DEFAULT_COLOR` is never applied and the glyph lands a hair off its own background.

Measured from the screenshot in the issue: glyphs `#dce3f8` on a `#cdd6f4` block, over a `#1e1e2e` terminal — Catppuccin Mocha, whose `fg` is exactly `#cdd6f4`. Running xterm's own `increaseLuminance` on (`#cdd6f4`, `#cdd6f4`) at ratio 1.1 returns `#dbe3f8` at contrast 1.13. That is the reported pixel.

We were the ones enabling the path: xterm defaults the option to `1` (off) and we set `1.1`. Desktop is affected because the DOM renderer is the default there — WebGL is opt-in — and the WebGL path resolves inverse correctly.

## The fix

Default `minimumContrastRatio` back to `1`.

It costs nothing, because 1.1 never bought anything. The option only engages below its threshold, i.e. essentially only when foreground equals background — and for such a glyph 1.1 yields:

| Theme | fg == bg lifted to | Contrast |
|---|---|---|
| Catppuccin Mocha | `#353543` | 1.36 |
| UniSSH Nebula | `#25272e` | 1.29 |
| Gruvbox Dark | `#3e3e3e` | 1.38 |
| Solarized Light | `#e3ddcc` | 1.26 |

AA is 4.5; "you can tell something is there" starts around 1.5–2. It turned invisible text into slightly-less-invisible text. The case it was written for — colour-0 text swallowed by the background — is already handled properly in `termToXterm`, which maps ANSI black to a lifted tone. And fg == bg is often deliberate: hidden password echo, progress bars drawn as background-coloured spaces.

`minContrast: true` still means 4.5. That stays an explicit accessibility choice.

## Known residue

With minimum contrast turned **on**, the same xterm bug reappears — at 4.5 the DOM renderer produces white on `#cdd6f4`, contrast 1.45. Any default-coloured inverse run is affected, not just pastes (`less` match highlights, some status lines). That half belongs upstream; noted next to the `4.5` in the source.

@foreignerby — a way to confirm the diagnosis on your machine: turning on GPU rendering in the terminal appearance settings should make it go away even before this lands, since the WebGL renderer handles inverse correctly.

## Testing

`termPrefs` test updated in lockstep; `vitest`, `tsc --noEmit`, `eslint` clean. The rendering itself was not reproduced on a Mac here — the diagnosis rests on the pixel measurements above and on reading the bundled xterm source.