### PR TITLE
fix(client): stop two window listeners from eating each other's keys

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -19,6 +19,7 @@ import { UpdateBanner } from "@/components/UpdateBanner";
 import { Sidebar, TitleBar, WindowControls } from "@/shell/Shell";
 import { ResizeEdges } from "@/shell/WindowChrome";
 import { isDesktopOs, isMac } from "@/bridge/platform";
+import { terminalOwnsTabDigits } from "@/support/hotkeys";
 import { useUpdate } from "@/store/update";
 import { BOOT_CHECK_DELAY_MS, PERIODIC_CHECK_MS } from "@/bridge/updater";
 
@@ -501,6 +502,11 @@ export function App() {
         e.preventDefault();
         useApp.getState().resetTermZoom();
       } else if (/[1-9]/.test(k)) {
+        // While the terminal is on screen these digits are its tab switcher, and
+        // both listeners are capture-phase on window — stopPropagation over there
+        // cannot silence this one. Routing anyway is how ⌘1 in a terminal used to
+        // switch to tab 1 and then throw the user out to Hosts.
+        if (terminalOwnsTabDigits(useApp.getState().route, e)) return;
         const r = ROUTES[parseInt(k, 10) - 1];
         if (r) {
           e.preventDefault();

--- a/client/src/shell/useTerminalShortcuts.ts
+++ b/client/src/shell/useTerminalShortcuts.ts
@@ -7,8 +7,9 @@
 //   macOS      → Cmd (metaKey)
 //   others     → Ctrl+Shift  (so a bare Ctrl+<key> still reaches the shell)
 // Shortcuts: new tab (T), local shell (⇧S), close pane/tab (W), split right (D)
-//   / down (E), jump to tab N (1..8, 9=last), focus prev/next pane (Arrows). Tab
-//   cycling is Ctrl+Tab / Ctrl+Shift+Tab on every platform.
+//   / down (E), jump to tab N (1..8, 9=last), focus prev/next pane (← →). Tab
+//   cycling is Ctrl+Tab / Ctrl+Shift+Tab on every platform. ↑ ↓ belong to
+//   ViewTerminal's prompt jumping — see paneFocusStep.
 //
 // The local shell is ⌘⇧S / Ctrl+Shift+S, and both halves of that are deliberate.
 // Not L (the obvious mnemonic): ⌘L / Ctrl+Shift+L is "lock the instance", and a
@@ -18,7 +19,22 @@
 import { useEffect } from "react";
 import { useApp, layoutPaneOrder } from "@/store/app";
 import { openLocalTerminal } from "@/store/ctx";
-import { isMac } from "@/bridge/platform";
+import { hasAppModifier } from "@/support/hotkeys";
+
+/** Which way ← / → move the focus, or null for a key that is not one of them.
+ *
+ *  ↑ / ↓ are deliberately absent. They were aliases of ← / → here — the pane
+ *  order is flat, so left/right already reach every pane — while ViewTerminal
+ *  binds them to prompt jumping (OSC 133). This listener is capture-phase on
+ *  `window` and stops propagation, so accepting them meant xterm never saw the
+ *  key and the jump silently became a pane switch in any tab with two panes.
+ *  The rule is now the same on every platform: ← → move panes, ↑ ↓ move by
+ *  prompt. */
+export function paneFocusStep(key: string): -1 | 1 | null {
+  if (key === "ArrowLeft") return -1;
+  if (key === "ArrowRight") return 1;
+  return null;
+}
 
 /** True for a real text field the user is typing into.
  *
@@ -34,12 +50,11 @@ function inTextField(target: EventTarget | null): boolean {
 export function useTerminalShortcuts(enabled: boolean): void {
   useEffect(() => {
     if (!enabled) return;
-    const mac = isMac();
     const onKey = (e: KeyboardEvent) => {
       const st = useApp.getState();
-      const chord = mac
-        ? e.metaKey && !e.ctrlKey && !e.altKey
-        : e.ctrlKey && e.shiftKey && !e.altKey && !e.metaKey;
+      // The same modifier rule App.tsx and the terminal's own key handler use,
+      // from one place — App.tsx has to ask about it to know when to stand down.
+      const chord = hasAppModifier(e);
 
       // A shell on this machine opens from anywhere: it creates its own tab and
       // routes to the terminal, so requiring you to already be there would make
@@ -120,19 +135,14 @@ export function useTerminalShortcuts(enabled: boolean): void {
         st.splitPane(active.id, active.activePaneId, "col");
         return;
       }
-      if (
-        e.key === "ArrowLeft" ||
-        e.key === "ArrowRight" ||
-        e.key === "ArrowUp" ||
-        e.key === "ArrowDown"
-      ) {
+      const step = paneFocusStep(e.key);
+      if (step) {
         const order = layoutPaneOrder(active.layout);
         if (order.length < 2) return;
         e.preventDefault();
         e.stopPropagation();
         const cur = order.indexOf(active.activePaneId);
-        const back = e.key === "ArrowLeft" || e.key === "ArrowUp";
-        const nxt = (cur + (back ? -1 : 1) + order.length) % order.length;
+        const nxt = (cur + step + order.length) % order.length;
         st.setActivePane(active.id, order[nxt]);
       }
     };

--- a/client/src/support/hotkeys.test.ts
+++ b/client/src/support/hotkeys.test.ts
@@ -1,0 +1,91 @@
+// Two window listeners in the capture phase decide these keys between them —
+// App.tsx's global chords and shell/useTerminalShortcuts' tabs and panes — and
+// neither can silence the other, because stopPropagation does not reach a
+// sibling on the same node. Both collisions that came out of that are pinned
+// here, at the only two points where the decision is a pure function.
+
+import { describe, expect, it } from "vitest";
+import { hasAppModifier, isAppChord, terminalOwnsTabDigits } from "./hotkeys";
+import { paneFocusStep } from "@/shell/useTerminalShortcuts";
+
+/** A keydown event with only the fields these predicates read. */
+function ev(init: { key?: string; code?: string } & Partial<Record<"metaKey" | "ctrlKey" | "shiftKey" | "altKey", boolean>>) {
+  return {
+    key: "",
+    code: "",
+    metaKey: false,
+    ctrlKey: false,
+    shiftKey: false,
+    altKey: false,
+    ...init,
+  } as KeyboardEvent;
+}
+
+describe("hasAppModifier", () => {
+  it("is ⌘ on macOS and Ctrl+Shift elsewhere", () => {
+    expect(hasAppModifier(ev({ key: "k", metaKey: true }), true)).toBe(true);
+    expect(hasAppModifier(ev({ key: "k", ctrlKey: true, shiftKey: true }), false)).toBe(true);
+    // A bare Ctrl belongs to readline off macOS; ⌘ means nothing on Linux.
+    expect(hasAppModifier(ev({ key: "k", ctrlKey: true }), false)).toBe(false);
+    expect(hasAppModifier(ev({ key: "k", metaKey: true }), false)).toBe(false);
+  });
+
+  it("never claims a chord carrying Alt", () => {
+    expect(hasAppModifier(ev({ key: "k", metaKey: true, altKey: true }), true)).toBe(false);
+    expect(hasAppModifier(ev({ key: "k", ctrlKey: true, shiftKey: true, altKey: true }), false)).toBe(false);
+  });
+
+  it("still backs isAppChord's key set", () => {
+    // isAppChord reads the real platform, which is "unknown" outside Tauri —
+    // i.e. the non-mac rule. Both halves have to hold: modifier AND key.
+    expect(isAppChord(ev({ key: "k", ctrlKey: true, shiftKey: true }))).toBe(true);
+    expect(isAppChord(ev({ key: "j", ctrlKey: true, shiftKey: true }))).toBe(false);
+    expect(isAppChord(ev({ key: "k", ctrlKey: true }))).toBe(false);
+  });
+});
+
+describe("terminalOwnsTabDigits", () => {
+  it("stands App.tsx down for ⌘1 while the terminal is on screen", () => {
+    expect(terminalOwnsTabDigits("terminal", ev({ key: "1", code: "Digit1", metaKey: true }), true)).toBe(true);
+  });
+
+  it("leaves the digits to the sections everywhere else", () => {
+    expect(terminalOwnsTabDigits("hosts", ev({ key: "1", code: "Digit1", metaKey: true }), true)).toBe(false);
+  });
+
+  it("reads e.code, because Shift makes e.key '!'", () => {
+    const shifted = ev({ key: "!", code: "Digit1", ctrlKey: true, shiftKey: true });
+    expect(terminalOwnsTabDigits("terminal", shifted, false)).toBe(true);
+  });
+
+  it("keeps a bare Ctrl+1 off macOS routing to the sections", () => {
+    // The terminal never claims it (its chord needs Shift), so App.tsx must not
+    // stand down — this is the one way to reach a section from the terminal there.
+    expect(terminalOwnsTabDigits("terminal", ev({ key: "1", code: "Digit1", ctrlKey: true }), false)).toBe(false);
+  });
+
+  it("ignores 0 and the letters", () => {
+    expect(terminalOwnsTabDigits("terminal", ev({ key: "0", code: "Digit0", metaKey: true }), true)).toBe(false);
+    expect(terminalOwnsTabDigits("terminal", ev({ key: "k", code: "KeyK", metaKey: true }), true)).toBe(false);
+  });
+});
+
+describe("paneFocusStep", () => {
+  it("moves focus on ← and →", () => {
+    expect(paneFocusStep("ArrowLeft")).toBe(-1);
+    expect(paneFocusStep("ArrowRight")).toBe(1);
+  });
+
+  // The whole point of the change: ↑ ↓ have to reach xterm, where ViewTerminal
+  // jumps between OSC 133 prompts. Claiming them here swallowed the jump in
+  // every split tab, on both platforms.
+  it("leaves ↑ and ↓ to prompt jumping", () => {
+    expect(paneFocusStep("ArrowUp")).toBe(null);
+    expect(paneFocusStep("ArrowDown")).toBe(null);
+  });
+
+  it("ignores everything else", () => {
+    expect(paneFocusStep("a")).toBe(null);
+    expect(paneFocusStep("Tab")).toBe(null);
+  });
+});

--- a/client/src/support/hotkeys.ts
+++ b/client/src/support/hotkeys.ts
@@ -40,15 +40,36 @@ const APP_CHORD_KEYS = new Set([
   "9", // sections
 ]);
 
-/** Whether a key event is an app-level chord the terminal must let through.
+/** The modifier half of an app chord, without asking which key it is.
  *
  *  ⌘ on macOS; Ctrl+**Shift** everywhere else. Not a bare Ctrl: Ctrl+K, Ctrl+L
  *  and Ctrl+T are readline's kill-line, clear and transpose, and a terminal
  *  that ate them to open a palette would be a worse terminal. Same rule the
- *  find bar already uses (⌘F / Ctrl+Shift+F). */
-export function isAppChord(ev: KeyboardEvent): boolean {
+ *  find bar already uses (⌘F / Ctrl+Shift+F).
+ *
+ *  `mac` is a parameter rather than a call to isMac() so the rule can be tested
+ *  for both platforms from one process. */
+export function hasAppModifier(ev: KeyboardEvent, mac = isMac()): boolean {
   if (ev.altKey) return false;
-  const modifier = isMac() ? ev.metaKey && !ev.ctrlKey : ev.ctrlKey && ev.shiftKey;
-  if (!modifier) return false;
+  return mac ? ev.metaKey && !ev.ctrlKey : ev.ctrlKey && ev.shiftKey && !ev.metaKey;
+}
+
+/** Whether a key event is an app-level chord the terminal must let through. */
+export function isAppChord(ev: KeyboardEvent): boolean {
+  if (!hasAppModifier(ev)) return false;
   return APP_CHORD_KEYS.has(ev.key.toLowerCase());
+}
+
+/** Whether a digit chord belongs to the terminal's tabs rather than to the
+ *  app's sections.
+ *
+ *  Both listeners sit on `window` in the capture phase, and stopPropagation
+ *  cannot silence a sibling on the same node — so on macOS ⌘1 used to jump to
+ *  terminal tab 1 *and* route the app to Hosts, whichever ran first. App.tsx
+ *  asks this before routing and stands down while the terminal is on screen.
+ *
+ *  Matched on `e.code`, the way useTerminalShortcuts matches it: with Shift
+ *  held, `e.key` is "!@#$%^&*(" on the usual layouts. */
+export function terminalOwnsTabDigits(route: string, ev: KeyboardEvent, mac = isMac()): boolean {
+  return route === "terminal" && hasAppModifier(ev, mac) && /^Digit[1-9]$/.test(ev.code);
 }


### PR DESCRIPTION
Two shortcut collisions, both found while writing the cheat-sheet in #44 and deliberately left out of it. `App.tsx` and `shell/useTerminalShortcuts.ts` both listen on `window` in the capture phase, and `stopPropagation()` cannot silence a sibling listener on the same node — so whichever registered first won, and the other shortcut lost.

## Prompt jumping was dead in every split tab

`useTerminalShortcuts` matched all four arrows for pane focus and never ruled out Shift (`chord` is `metaKey && !ctrlKey && !altKey` on macOS — Shift is not in it). Being capture-phase on `window`, it consumed `Cmd+Shift+Up` before the event reached xterm's textarea, which is where `ViewTerminal`'s OSC 133 handler lives. So jumping to the previous prompt worked only in an unsplit tab — the one case where the branch returns early, before `preventDefault()`.

Off macOS the two chords are literally identical (`Ctrl+Shift+<arrows>` for both), so no amount of modifier-checking separates them; one function had to give up the arrows.

Focus now moves on the horizontal arrows only. Nothing is lost: `layoutPaneOrder` is a flat list and `Left`/`Right` already reach every pane, with `Up`/`Down` as pure aliases. The rule is now the same on both platforms:

| | Focus pane | Jump between prompts |
|---|---|---|
| macOS | `Cmd + Left/Right` | `Cmd + Shift + Up/Down` |
| Windows / Linux | `Ctrl + Shift + Left/Right` | `Ctrl + Shift + Up/Down` |

## Cmd+1 in a terminal threw you out to Hosts

The terminal matches tab digits by `e.code`, `App.tsx` routes to sections by `e.key`, and on macOS both matched `Cmd+1`: the tab switched, then the app navigated away from the terminal. Off macOS the same collision was hidden by accident — Shift turns the digit into `!@#$%^&*(`, which `App.tsx`'s `/[1-9]/` never matches.

`App.tsx` now stands down for those digits while the terminal is the route and the event carries the app modifier. A bare `Ctrl+1` from the terminal keeps switching sections off macOS, because the terminal never claims it (its chord requires Shift).

## Shape of the change

The modifier rule moved into `support/hotkeys.ts` as `hasAppModifier` — `isAppChord` already held half of it, and `App.tsx` now needs to ask about it to know when to stand down. It takes the platform as a parameter rather than calling `isMac()`, so both platforms' rules are testable from one process. The two decisions that used to be inline conditions are now pure functions (`terminalOwnsTabDigits`, `paneFocusStep`) with 11 unit tests pinning exactly the cases that were broken.

One incidental behaviour change: off macOS `hasAppModifier` also rejects a chord carrying Meta, which the `isAppChord` copy did not. `Ctrl+Shift+Super+K` is nobody's shortcut.

## Testing

`npm run lint`, `npm run typecheck`, `npx vitest run` — 376 tests green, 11 new.

**Not verified on a device**, and this one is keyboard behaviour, so it deserves a real pass before release: split a tab and check that `Cmd+Shift+Up` still jumps prompts in a shell with OSC 133 marks while `Cmd+Left/Right` moves between panes, and that `Cmd+1` inside the terminal stays in the terminal.

## Follows

Depends on nothing, but #44 documents these keys. Once this lands, the sheet there gets its prompt-jump row back and the pane-focus row narrows to `Left/Right`.
