### PR TITLE
fix(server): stop logging a setup code the operator already holds

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -260,8 +260,10 @@ zero-knowledge crypto boundary above is what actually protects vault *contents*.
 The current onboarding / sign-in entry points all verify a **self-attested keyset
 registration** and never see plaintext keys:
 
-- **Claim** (`POST /v1/claim`) — a first-boot **setup code** (printed to the log
-  while the instance is unclaimed, stored only as `sha256`) plus a keyset
+- **Claim** (`POST /v1/claim`) — a first-boot **setup code** (stored only as
+  `sha256`; printed to the log while the instance is unclaimed **only when the
+  server generated it**, since the log is then its sole channel — a code pinned
+  via `[setup].code` / `UNISSH__SETUP__CODE` is never logged) plus a keyset
   registration wins a single-winner claim of the empty instance, creating the
   owner and first space. The code is valid only while unclaimed.
 - **Invite / join** (`POST /v1/invite`, `POST /v1/join`) — a space admin issues a

--- a/server/config.example.toml
+++ b/server/config.example.toml
@@ -54,7 +54,9 @@ metrics_bind = "127.0.0.1:9090"
 [setup]
 # code = "" → empty → a random setup code is printed to the server log on first
 # boot (while the instance is unclaimed); the first user claims the instance with
-# it. Set a value to pin a deterministic code for IaC/tests. Env: UNISSH__SETUP__CODE=...
+# it. Set a value to pin a deterministic code for IaC/tests — a pinned code is
+# NEVER printed to the log (you already hold it; logging it would only spread it).
+# Env: UNISSH__SETUP__CODE=...
 code = ""
 
 [oidc]

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -52,14 +52,21 @@ pub async fn build_state(
     //   * empty + a hash already exists → a code was issued before; keep it (do NOT
     //     regenerate — we only have its hash, not the plaintext).
     //   * empty + no hash yet (first-ever boot) → mint one and print it exactly once.
+    //
+    // The log carries the plaintext ONLY when we minted it, because then the log is
+    // the sole channel it exists on. An operator-pinned code is already in their
+    // hands (env/config/IaC secret store), so printing it would only copy a live
+    // credential into `docker compose logs`, journald and every log shipper
+    // downstream — a leak that buys nothing.
     if instance_row.claimed == 0 {
         if !config.setup.code.is_empty() {
-            let code = config.setup.code.clone();
             store
-                .set_setup_code_hash(&ids::sha256(code.as_bytes()))
+                .set_setup_code_hash(&ids::sha256(config.setup.code.as_bytes()))
                 .await?;
-            tracing::warn!(%code, "server unclaimed — claim it from a client with this setup code");
-            println!("SETUP CODE: {code}");
+            tracing::warn!(
+                "server unclaimed — claim it from a client with the setup code pinned in your \
+                 configuration ([setup].code / UNISSH__SETUP__CODE). Not logged: you already have it"
+            );
         } else if instance_row.setup_code_hash.is_some() {
             tracing::warn!(
                 "server unclaimed — a setup code was already issued on an earlier boot and is \


### PR DESCRIPTION
## What

An unclaimed server publishes a setup code so the first client can claim it, and the boot log is how the operator receives it. That is true only when the **server minted** the code. A code pinned through `[setup].code` / `UNISSH__SETUP__CODE` was printed exactly the same way, twice — as a structured `code` field on the `tracing::warn!` and again on stdout as `SETUP CODE: …`.

That copies a live claim credential the operator already holds into `docker compose logs`, journald, and every log shipper downstream. It buys nothing: the value came *from* them.

## Change

- `server/src/lib.rs` — the pinned branch reports that the instance is unclaimed and where its code came from, without the value. The generated branch is untouched; there the log is the only channel the plaintext exists on.
- `server/config.example.toml`, `SECURITY.md` — both described the code as printed while unclaimed, full stop. They now carry the distinction.

## Scope check

This was the only leak path. `GET /v1/admin/config` already masks `setup.code` (`server/src/modules/admin.rs`), and `impl Debug for SetupConfig` redacts it (`server/src/config.rs:297`), so a `?config` in a log or a panic message was already safe. `README.md` needs no change — its Quick Start describes the default (generated) path, and the FAQ already says "Pinned a code via `UNISSH__SETUP__CODE`? Use that value."

## Verification

`cargo fmt --all --check` passes. The tree is not compiled locally (this box OOMs rustc), so CI is the gate for type-check, clippy and the server tests. No test asserted on the removed output.

Related: #58 — the same code path, from the other direction (an operator who *lost* a generated code has no way to get a new one).
