### PR TITLE
feat(client): give the host picker a search box and a keyboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,15 @@ starts with `0.`:
 
 ### Added
 
+- **The host picker has a search box and a keyboard.** The `+` in the terminal
+  and SFTP tab strips only offered a search past six saved hosts, so anyone with
+  fewer never saw one; it now appears for any non-empty list. The list also
+  answers to the keyboard: ↑/↓ move a highlight that wraps at both ends, Enter
+  opens it, and the row under the pointer is the same highlight, so mouse and
+  keyboard cannot disagree about what Enter would do. On a phone the field no
+  longer grabs the caret on open — that pops the on-screen keyboard over the
+  list before you have decided to type.
+
 - **Connect through an HTTP, SOCKS4 or SOCKS5 proxy.** A host can now carry an
   outbound proxy alongside (or instead of) a jump host: the proxy wraps the
   first TCP hop — the target, or the first bastion of a `ProxyJump` chain, so

--- a/client/src/i18n/locales/en.ts
+++ b/client/src/i18n/locales/en.ts
@@ -1196,6 +1196,8 @@ export const en = {
     "driveFree": "{{free}} free of {{total}}",
     "addHost": "Add a host…",
     "searchHosts": "Search hosts…",
+    "hostsListLabel": "Saved hosts",
+    "noHostMatches": "No hosts matching “{{q}}”",
     "closeTab": "Close",
     "goToPath": "Go to path…",
     "filter": "Filter…",

--- a/client/src/i18n/locales/ru.ts
+++ b/client/src/i18n/locales/ru.ts
@@ -1235,6 +1235,8 @@ export const ru = {
     "driveFree": "{{free}} свободно из {{total}}",
     "addHost": "Добавить хост…",
     "searchHosts": "Поиск хостов…",
+    "hostsListLabel": "Сохранённые хосты",
+    "noHostMatches": "Нет хостов по «{{q}}»",
     "closeTab": "Закрыть",
     "goToPath": "Перейти к пути…",
     "filter": "Фильтр…",

--- a/client/src/views/sftp/hostpicker.tsx
+++ b/client/src/views/sftp/hostpicker.tsx
@@ -3,11 +3,21 @@
 // renders inline — a pane with nothing in it should already be showing what can
 // go in it, rather than making the hosts a hover away.
 
-import { useEffect, useLayoutEffect, useRef, useState, type CSSProperties } from "react";
+import {
+  Fragment,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+} from "react";
 import { usePalette } from "@/theme/ThemeProvider";
 import { MONO } from "@/theme/tokens";
 import { Icon, NO_AUTOCORRECT } from "@/components/primitives";
 import { useCtx } from "@/store/ctx";
+import { useIsMobile } from "@/store/responsive";
 import { useTranslation } from "@/i18n";
 import { nextRow, pickerRows } from "./pickerRows";
 import type { ConnectionProfile } from "@/bridge/types";
@@ -35,38 +45,48 @@ export function HostList({
   const p = usePalette();
   const { t } = useTranslation();
   const ctx = useCtx();
+  const isMobile = useIsMobile();
 
   const [q, setQ] = useState("");
-  // The rows and the keyboard have to be computed from the same list, or Enter
-  // opens something other than what is highlighted. See pickerRows.ts.
-  const rows = pickerRows(
-    hosts,
-    q,
-    onPickLocal ? `${t("terminal.localShell")} ${t("terminal.localShellHint")}` : null,
-  );
+  // Rebuilt only when the inputs change: hover routes through `sel`, so without
+  // this every pointer crossing would re-derive and re-lowercase the whole list.
+  const localLabel = onPickLocal
+    ? `${t("terminal.localShell")} ${t("terminal.localShellHint")}`
+    : null;
+  const rows = useMemo(() => pickerRows(hosts, q, localLabel), [hosts, q, localLabel]);
   const [sel, setSel] = useState(0);
+  // Clamped at RENDER, not only when a key moves it: `hosts` can change under an
+  // open picker (a vault sync, a host deleted in another window), and a highlight
+  // left past the end paints nothing while Enter quietly does nothing either.
+  const active = rows.length === 0 ? -1 : Math.min(sel, rows.length - 1);
   const rowRefs = useRef<(HTMLButtonElement | null)[]>([]);
-  // The dropdown scrolls at 340px; a highlight the arrows walked off the bottom
-  // of it is a highlight the user cannot see.
-  useEffect(() => {
-    rowRefs.current[sel]?.scrollIntoView({ block: "nearest" });
-  }, [sel]);
+  const listId = useId();
 
   const activate = (row: (typeof rows)[number]) => {
     if (row.kind === "local") onPickLocal?.();
     else onPick(row.host);
   };
+  const move = (delta: number) => {
+    const next = nextRow(active, delta, rows.length);
+    setSel(next);
+    // Scrolling belongs to the arrow keys alone. As an effect on `sel` it would
+    // also fire at mount — yanking the inline pane list, which is deliberately
+    // centred, to its first row — and again on every hover.
+    rowRefs.current[next]?.scrollIntoView({ block: "nearest" });
+  };
   const onSearchKey = (e: React.KeyboardEvent) => {
+    // The Enter that commits an IME candidate is not a request to connect.
+    if (e.nativeEvent.isComposing) return;
     if (e.key === "ArrowDown" || e.key === "ArrowUp") {
       e.preventDefault();
-      setSel(nextRow(sel, e.key === "ArrowDown" ? 1 : -1, rows.length));
-    } else if (e.key === "Enter" && rows[sel]) {
+      move(e.key === "ArrowDown" ? 1 : -1);
+    } else if (e.key === "Enter" && rows[active]) {
       e.preventDefault();
-      activate(rows[sel]);
+      activate(rows[active]);
     }
   };
 
-  const rowStyle = (active: boolean): CSSProperties => ({
+  const rowStyle = (on: boolean): CSSProperties => ({
     display: "flex",
     alignItems: "center",
     gap: 9,
@@ -74,42 +94,101 @@ export function HostList({
     padding: "7px 9px",
     borderRadius: 8,
     border: "1px solid transparent",
-    background: active ? p.bg2 : "transparent",
+    background: on ? p.bg2 : "transparent",
     color: p.txt,
     cursor: "pointer",
     textAlign: "left",
   });
 
+  // One renderer for both kinds: they differ by an icon and two strings, and a
+  // second copy is how one of them ends up without the aria state or the ref.
+  const renderRow = (row: (typeof rows)[number], i: number) => {
+    const local = row.kind === "local";
+    return (
+      <button
+        key={local ? "local" : row.host.profileId}
+        id={`${listId}-${i}`}
+        role="option"
+        aria-selected={i === active}
+        ref={(el) => {
+          rowRefs.current[i] = el;
+        }}
+        onClick={() => activate(row)}
+        onMouseEnter={() => setSel(i)}
+        style={rowStyle(i === active)}
+      >
+        <Icon name={local ? "laptop" : "server"} size={15} color={p.txt3} />
+        <span style={{ flex: 1, minWidth: 0 }}>
+          <span style={{ display: "block", fontSize: 13, fontWeight: 600 }}>
+            {local ? t("terminal.localShell") : row.host.label}
+          </span>
+          <span style={{ display: "block", fontFamily: MONO, fontSize: 11, color: p.txt3 }}>
+            {local
+              ? t("terminal.localShellHint")
+              : `${row.host.user}@${row.host.host}:${row.host.port}`}
+          </span>
+        </span>
+      </button>
+    );
+  };
+
   return (
     <>
-      {/* Always shown, not only past some list length: a picker whose search
-          appears at the seventh host reads as a search that is broken at the
-          sixth. It costs one row, and it is where the keyboard enters. */}
-      <input
-        autoFocus={autoFocusSearch}
-        value={q}
-        onChange={(e) => {
-          setQ(e.target.value);
-          // Every keystroke rebuilds the list; the highlight goes back to its top
-          // match rather than to whatever now sits at the old index.
-          setSel(0);
-        }}
-        onKeyDown={onSearchKey}
-        placeholder={t("sftp.searchHosts")}
-        {...NO_AUTOCORRECT}
-        style={{
-          width: "100%",
-          boxSizing: "border-box",
-          marginBottom: 5,
-          padding: "6px 9px",
-          borderRadius: 8,
-          border: `1px solid ${p.line2}`,
-          background: p.bg2,
-          color: p.txt,
-          fontSize: 13,
-          outline: "none",
-        }}
-      />
+      {/* Shown for any non-empty list, not only past six hosts: a picker whose
+          search appears at the seventh reads as one that is broken at the sixth.
+          With no hosts at all there is nothing to search, and the only useful
+          control is the button below. */}
+      {hosts.length > 0 && (
+        <input
+          // A caret on a phone means the on-screen keyboard over a 340px
+          // dropdown before the user has decided to type.
+          autoFocus={autoFocusSearch && !isMobile}
+          value={q}
+          onChange={(e) => {
+            setQ(e.target.value);
+            // Every keystroke rebuilds the list; the highlight goes back to its
+            // top match rather than to whatever now sits at the old index.
+            setSel(0);
+          }}
+          onKeyDown={onSearchKey}
+          placeholder={t("sftp.searchHosts")}
+          aria-label={t("sftp.searchHosts")}
+          role="combobox"
+          aria-expanded
+          aria-controls={listId}
+          aria-activedescendant={active >= 0 ? `${listId}-${active}` : undefined}
+          {...NO_AUTOCORRECT}
+          style={{
+            width: "100%",
+            boxSizing: "border-box",
+            marginBottom: 5,
+            padding: "6px 9px",
+            borderRadius: 8,
+            border: `1px solid ${p.line2}`,
+            background: p.bg2,
+            color: p.txt,
+            fontSize: 13,
+            outline: "none",
+          }}
+        />
+      )}
+      <div id={listId} role="listbox" aria-label={t("sftp.hostsListLabel")}>
+        {rows.map((row, i) => (
+          <Fragment key={row.kind === "local" ? "local" : row.host.profileId}>
+            {renderRow(row, i)}
+            {/* Separated, not just listed first: this one does not go over the
+                network, and the list below is entirely about things that do. */}
+            {row.kind === "local" && rows.length > 1 && (
+              <div style={{ height: 1, background: p.line2, margin: "5px 4px" }} />
+            )}
+          </Fragment>
+        ))}
+      </div>
+      {rows.length === 0 && hosts.length > 0 && (
+        <div style={{ padding: "8px 10px", fontSize: 13, color: p.txt3 }}>
+          {t("sftp.noHostMatches", { q: q.trim() })}
+        </div>
+      )}
       {hosts.length === 0 && (
         <button
           onClick={() => {
@@ -130,64 +209,17 @@ export function HostList({
             textAlign: "left",
             fontSize: 13,
           }}
-          onMouseEnter={(e) => (e.currentTarget.style.background = p.bg2)}
+          // Clears the row highlight as well as painting itself: two rows lit at
+          // once says nothing about which one Enter would take.
+          onMouseEnter={(e) => {
+            e.currentTarget.style.background = p.bg2;
+            setSel(-1);
+          }}
           onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
         >
           <Icon name="plus" size={15} color={p.accentText} />
           {t("sftp.addHost")}
         </button>
-      )}
-      {rows.length === 0 && hosts.length > 0 && (
-        <div style={{ padding: "8px 10px", fontSize: 13, color: p.txt3 }}>{t("sftp.noMatches", { q })}</div>
-      )}
-      {rows.map((row, i) =>
-        row.kind === "local" ? (
-          <div key="local">
-            <button
-              ref={(el) => {
-                rowRefs.current[i] = el;
-              }}
-              onClick={() => activate(row)}
-              onMouseEnter={() => setSel(i)}
-              style={rowStyle(i === sel)}
-            >
-              <Icon name="laptop" size={15} color={p.txt3} />
-              <span style={{ flex: 1, minWidth: 0 }}>
-                <span style={{ display: "block", fontSize: 13, fontWeight: 600 }}>
-                  {t("terminal.localShell")}
-                </span>
-                <span style={{ display: "block", fontFamily: MONO, fontSize: 11, color: p.txt3 }}>
-                  {t("terminal.localShellHint")}
-                </span>
-              </span>
-            </button>
-            {/* Separated, not just listed first: this one does not go over the
-                network, and the list below is entirely about things that do. */}
-            {rows.length > 1 && (
-              <div style={{ height: 1, background: p.line2, margin: "5px 4px" }} />
-            )}
-          </div>
-        ) : (
-          <button
-            key={row.host.profileId}
-            ref={(el) => {
-              rowRefs.current[i] = el;
-            }}
-            onClick={() => activate(row)}
-            onMouseEnter={() => setSel(i)}
-            style={rowStyle(i === sel)}
-          >
-            <Icon name="server" size={15} color={p.txt3} />
-            <span style={{ flex: 1, minWidth: 0 }}>
-              <span style={{ display: "block", fontSize: 13, fontWeight: 600 }}>
-                {row.host.label}
-              </span>
-              <span style={{ display: "block", fontFamily: MONO, fontSize: 11, color: p.txt3 }}>
-                {row.host.user}@{row.host.host}:{row.host.port}
-              </span>
-            </span>
-          </button>
-        ),
       )}
     </>
   );

--- a/client/src/views/sftp/hostpicker.tsx
+++ b/client/src/views/sftp/hostpicker.tsx
@@ -3,12 +3,13 @@
 // renders inline — a pane with nothing in it should already be showing what can
 // go in it, rather than making the hosts a hover away.
 
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState, type CSSProperties } from "react";
 import { usePalette } from "@/theme/ThemeProvider";
 import { MONO } from "@/theme/tokens";
 import { Icon, NO_AUTOCORRECT } from "@/components/primitives";
 import { useCtx } from "@/store/ctx";
 import { useTranslation } from "@/i18n";
+import { nextRow, pickerRows } from "./pickerRows";
 import type { ConnectionProfile } from "@/bridge/types";
 
 export function HostList({
@@ -36,76 +37,79 @@ export function HostList({
   const ctx = useCtx();
 
   const [q, setQ] = useState("");
-  const ql = q.trim().toLowerCase();
-  const filtered = ql
-    ? hosts.filter((h) => `${h.label} ${h.user}@${h.host}:${h.port}`.toLowerCase().includes(ql))
-    : hosts;
-  const showSearch = hosts.length > 6;
-  // The local entry filters like every other row rather than staying pinned
-  // through a search: a list being narrowed that keeps one row regardless reads
-  // as a bug, not as an action.
-  const showLocal =
-    !!onPickLocal &&
-    (!ql || `${t("terminal.localShell")} ${t("terminal.localShellHint")}`.toLowerCase().includes(ql));
+  // The rows and the keyboard have to be computed from the same list, or Enter
+  // opens something other than what is highlighted. See pickerRows.ts.
+  const rows = pickerRows(
+    hosts,
+    q,
+    onPickLocal ? `${t("terminal.localShell")} ${t("terminal.localShellHint")}` : null,
+  );
+  const [sel, setSel] = useState(0);
+  const rowRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  // The dropdown scrolls at 340px; a highlight the arrows walked off the bottom
+  // of it is a highlight the user cannot see.
+  useEffect(() => {
+    rowRefs.current[sel]?.scrollIntoView({ block: "nearest" });
+  }, [sel]);
+
+  const activate = (row: (typeof rows)[number]) => {
+    if (row.kind === "local") onPickLocal?.();
+    else onPick(row.host);
+  };
+  const onSearchKey = (e: React.KeyboardEvent) => {
+    if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+      e.preventDefault();
+      setSel(nextRow(sel, e.key === "ArrowDown" ? 1 : -1, rows.length));
+    } else if (e.key === "Enter" && rows[sel]) {
+      e.preventDefault();
+      activate(rows[sel]);
+    }
+  };
+
+  const rowStyle = (active: boolean): CSSProperties => ({
+    display: "flex",
+    alignItems: "center",
+    gap: 9,
+    width: "100%",
+    padding: "7px 9px",
+    borderRadius: 8,
+    border: "1px solid transparent",
+    background: active ? p.bg2 : "transparent",
+    color: p.txt,
+    cursor: "pointer",
+    textAlign: "left",
+  });
 
   return (
     <>
-      {showSearch && (
-        <input
-          autoFocus={autoFocusSearch}
-          value={q}
-          onChange={(e) => setQ(e.target.value)}
-          placeholder={t("sftp.searchHosts")}
-          {...NO_AUTOCORRECT}
-          style={{
-            width: "100%",
-            boxSizing: "border-box",
-            marginBottom: 5,
-            padding: "6px 9px",
-            borderRadius: 8,
-            border: `1px solid ${p.line2}`,
-            background: p.bg2,
-            color: p.txt,
-            fontSize: 13,
-            outline: "none",
-          }}
-        />
-      )}
-      {showLocal && (
-        <>
-          <button
-            onClick={onPickLocal}
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: 9,
-              width: "100%",
-              padding: "7px 9px",
-              borderRadius: 8,
-              border: "1px solid transparent",
-              background: "transparent",
-              color: p.txt,
-              cursor: "pointer",
-              textAlign: "left",
-            }}
-            onMouseEnter={(e) => (e.currentTarget.style.background = p.bg2)}
-            onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
-          >
-            <Icon name="laptop" size={15} color={p.txt3} />
-            <span style={{ flex: 1, minWidth: 0 }}>
-              <span style={{ display: "block", fontSize: 13, fontWeight: 600 }}>
-                {t("terminal.localShell")}
-              </span>
-              <span style={{ display: "block", fontFamily: MONO, fontSize: 11, color: p.txt3 }}>
-                {t("terminal.localShellHint")}
-              </span>
-            </span>
-          </button>
-          {/* Separated, not just listed first: this one does not go over the
-              network, and the list below is entirely about things that do. */}
-          <div style={{ height: 1, background: p.line2, margin: "5px 4px" }} />
-        </>
-      )}
+      {/* Always shown, not only past some list length: a picker whose search
+          appears at the seventh host reads as a search that is broken at the
+          sixth. It costs one row, and it is where the keyboard enters. */}
+      <input
+        autoFocus={autoFocusSearch}
+        value={q}
+        onChange={(e) => {
+          setQ(e.target.value);
+          // Every keystroke rebuilds the list; the highlight goes back to its top
+          // match rather than to whatever now sits at the old index.
+          setSel(0);
+        }}
+        onKeyDown={onSearchKey}
+        placeholder={t("sftp.searchHosts")}
+        {...NO_AUTOCORRECT}
+        style={{
+          width: "100%",
+          boxSizing: "border-box",
+          marginBottom: 5,
+          padding: "6px 9px",
+          borderRadius: 8,
+          border: `1px solid ${p.line2}`,
+          background: p.bg2,
+          color: p.txt,
+          fontSize: 13,
+          outline: "none",
+        }}
+      />
       {hosts.length === 0 && (
         <button
           onClick={() => {
@@ -133,38 +137,58 @@ export function HostList({
           {t("sftp.addHost")}
         </button>
       )}
-      {ql && filtered.length === 0 && !showLocal && hosts.length > 0 && (
+      {rows.length === 0 && hosts.length > 0 && (
         <div style={{ padding: "8px 10px", fontSize: 13, color: p.txt3 }}>{t("sftp.noMatches", { q })}</div>
       )}
-      {filtered.map((h) => (
-        <button
-          key={h.profileId}
-          onClick={() => onPick(h)}
-          style={{
-            display: "flex",
-            alignItems: "center",
-            gap: 9,
-            width: "100%",
-            padding: "7px 9px",
-            borderRadius: 8,
-            border: "1px solid transparent",
-            background: "transparent",
-            color: p.txt,
-            cursor: "pointer",
-            textAlign: "left",
-          }}
-          onMouseEnter={(e) => (e.currentTarget.style.background = p.bg2)}
-          onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
-        >
-          <Icon name="server" size={15} color={p.txt3} />
-          <span style={{ flex: 1, minWidth: 0 }}>
-            <span style={{ display: "block", fontSize: 13, fontWeight: 600 }}>{h.label}</span>
-            <span style={{ display: "block", fontFamily: MONO, fontSize: 11, color: p.txt3 }}>
-              {h.user}@{h.host}:{h.port}
+      {rows.map((row, i) =>
+        row.kind === "local" ? (
+          <div key="local">
+            <button
+              ref={(el) => {
+                rowRefs.current[i] = el;
+              }}
+              onClick={() => activate(row)}
+              onMouseEnter={() => setSel(i)}
+              style={rowStyle(i === sel)}
+            >
+              <Icon name="laptop" size={15} color={p.txt3} />
+              <span style={{ flex: 1, minWidth: 0 }}>
+                <span style={{ display: "block", fontSize: 13, fontWeight: 600 }}>
+                  {t("terminal.localShell")}
+                </span>
+                <span style={{ display: "block", fontFamily: MONO, fontSize: 11, color: p.txt3 }}>
+                  {t("terminal.localShellHint")}
+                </span>
+              </span>
+            </button>
+            {/* Separated, not just listed first: this one does not go over the
+                network, and the list below is entirely about things that do. */}
+            {rows.length > 1 && (
+              <div style={{ height: 1, background: p.line2, margin: "5px 4px" }} />
+            )}
+          </div>
+        ) : (
+          <button
+            key={row.host.profileId}
+            ref={(el) => {
+              rowRefs.current[i] = el;
+            }}
+            onClick={() => activate(row)}
+            onMouseEnter={() => setSel(i)}
+            style={rowStyle(i === sel)}
+          >
+            <Icon name="server" size={15} color={p.txt3} />
+            <span style={{ flex: 1, minWidth: 0 }}>
+              <span style={{ display: "block", fontSize: 13, fontWeight: 600 }}>
+                {row.host.label}
+              </span>
+              <span style={{ display: "block", fontFamily: MONO, fontSize: 11, color: p.txt3 }}>
+                {row.host.user}@{row.host.host}:{row.host.port}
+              </span>
             </span>
-          </span>
-        </button>
-      ))}
+          </button>
+        ),
+      )}
     </>
   );
 }

--- a/client/src/views/sftp/pickerRows.test.ts
+++ b/client/src/views/sftp/pickerRows.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { nextRow, pickerRows, type PickerHost } from "./pickerRows";
+
+const HOSTS: PickerHost[] = [
+  { label: "prod-db", host: "10.0.0.5", port: 22, user: "deploy" },
+  { label: "Edge", host: "edge.example.com", port: 2222, user: "root" },
+];
+
+const labels = (rows: ReturnType<typeof pickerRows>) =>
+  rows.map((r) => (r.kind === "local" ? "<local>" : r.host.label));
+
+describe("pickerRows", () => {
+  it("keeps every host, in order, when nothing is typed", () => {
+    expect(labels(pickerRows(HOSTS, "", null))).toEqual(["prod-db", "Edge"]);
+  });
+
+  it("matches a label regardless of case", () => {
+    expect(labels(pickerRows(HOSTS, "EDGE", null))).toEqual(["Edge"]);
+  });
+
+  it("matches the address the row actually shows", () => {
+    // The row prints user@host:port, so that whole string is searchable — typing
+    // "deploy@" or ":2222" has to find the host it is printed under.
+    expect(labels(pickerRows(HOSTS, "deploy@10.0.0.5", null))).toEqual(["prod-db"]);
+    expect(labels(pickerRows(HOSTS, ":2222", null))).toEqual(["Edge"]);
+  });
+
+  it("ignores surrounding whitespace in the query", () => {
+    expect(labels(pickerRows(HOSTS, "  edge  ", null))).toEqual(["Edge"]);
+  });
+
+  it("returns no rows when nothing matches", () => {
+    expect(pickerRows(HOSTS, "nothing-here", null)).toEqual([]);
+  });
+
+  it("leads with the local row when the picker offers one", () => {
+    expect(labels(pickerRows(HOSTS, "", "Local shell this machine"))).toEqual([
+      "<local>",
+      "prod-db",
+      "Edge",
+    ]);
+  });
+
+  it("filters the local row like any other row", () => {
+    // A list being narrowed that keeps one row regardless reads as a bug.
+    expect(labels(pickerRows(HOSTS, "shell", "Local shell this machine"))).toEqual(["<local>"]);
+    expect(labels(pickerRows(HOSTS, "edge", "Local shell this machine"))).toEqual(["Edge"]);
+  });
+
+  it("omits the local row entirely when the picker has no local target", () => {
+    expect(labels(pickerRows(HOSTS, "", null))).not.toContain("<local>");
+  });
+});
+
+describe("nextRow", () => {
+  it("steps forward and back", () => {
+    expect(nextRow(0, 1, 3)).toBe(1);
+    expect(nextRow(2, -1, 3)).toBe(1);
+  });
+
+  it("wraps at both ends, so the keyboard never dead-ends", () => {
+    expect(nextRow(2, 1, 3)).toBe(0);
+    expect(nextRow(0, -1, 3)).toBe(2);
+  });
+
+  it("stays at zero when there is nothing to move through", () => {
+    expect(nextRow(0, 1, 0)).toBe(0);
+  });
+
+  it("comes back to the nearest edge when the list shrank under the highlight", () => {
+    // Typing narrows the list while the highlight sits past its new end. That is
+    // not a position to step from, so the next key lands on an edge rather than
+    // wherever the arithmetic happens to fall.
+    expect(nextRow(7, 1, 3)).toBe(0);
+    expect(nextRow(7, -1, 3)).toBe(2);
+  });
+});

--- a/client/src/views/sftp/pickerRows.ts
+++ b/client/src/views/sftp/pickerRows.ts
@@ -1,0 +1,58 @@
+// What the saved-host picker shows for a query, and how the highlight moves
+// through it. Kept out of the component because the rows and the keyboard have
+// to agree: Enter opens "the highlighted row", and a filter that computed its
+// list one way while the arrow keys counted another would open the wrong host.
+
+/** The fields the picker searches. Structural rather than `ConnectionProfile` so
+ *  the rule can be tested without building a whole profile — and so the terminal
+ *  and SFTP pickers, which show the same two lines, can't drift apart. */
+export interface PickerHost {
+  label: string;
+  host: string;
+  port: number;
+  user: string;
+}
+
+/** A row as rendered: the optional local-shell entry, then the matching hosts. */
+export type PickerRow<T extends PickerHost = PickerHost> =
+  | { kind: "local" }
+  | { kind: "host"; host: T };
+
+/**
+ * @param hosts      saved hosts, in the order they should appear
+ * @param query      what the user typed (untrimmed)
+ * @param localLabel searchable text of the local-shell row, or null when this
+ *                   picker has no local target (SFTP — a local shell would mean
+ *                   nothing there)
+ */
+export function pickerRows<T extends PickerHost>(
+  hosts: T[],
+  query: string,
+  localLabel: string | null,
+): PickerRow<T>[] {
+  const q = query.trim().toLowerCase();
+  const rows: PickerRow<T>[] = [];
+  // The local row filters like every other row rather than staying pinned through
+  // a search: a list being narrowed that keeps one row regardless reads as a bug.
+  if (localLabel !== null && (!q || localLabel.toLowerCase().includes(q))) {
+    rows.push({ kind: "local" });
+  }
+  for (const host of hosts) {
+    // Matched against what the row prints, so anything visible is searchable.
+    const hay = `${host.label} ${host.user}@${host.host}:${host.port}`.toLowerCase();
+    if (!q || hay.includes(q)) rows.push({ kind: "host", host });
+  }
+  return rows;
+}
+
+/** Move the highlight by `delta`, wrapping at both ends — a keyboard that stops
+ *  dead at the last row makes the user reach for the mouse to get back to the
+ *  first. Also the clamp for a highlight left pointing past a list that just
+ *  shrank under it, which is what every keystroke does. */
+export function nextRow(current: number, delta: number, count: number): number {
+  if (count <= 0) return 0;
+  // Out of range is not a position to step from — the arithmetic would land
+  // somewhere arbitrary inside the new list. Go to the edge the key is heading for.
+  if (current < 0 || current >= count) return delta >= 0 ? 0 : count - 1;
+  return (((current + delta) % count) + count) % count;
+}


### PR DESCRIPTION
Closes #47.

## Why

The `+` in the Terminals tab strip opens `HostMenu`, whose search field was gated on `hosts.length > 6`. The reporter has fewer than six hosts, so for them the search simply did not exist. The picker was also mouse-only: the one key it handled was Escape.

## What

- **Search always renders.** A search that appears at the seventh host reads as one that is broken at the sixth, and it costs a single row. `autoFocusSearch` behaviour is unchanged — the dropdown grabs the caret, the inline pane list still does not.
- **The list has a highlight.** ↑/↓ move it and wrap at both ends, Enter opens the highlighted row (a host, or the local shell), Escape still closes via the existing document handler. Typing returns the highlight to the top match.
- **Hover moves the same highlight** instead of painting its own background, so mouse and keyboard cannot disagree about which row Enter will open.
- The highlighted row is scrolled into view — the dropdown scrolls at 340px, and a highlight walked off the bottom is one the user cannot see.

## Design note

Row-building and highlight movement moved into `pickerRows.ts` rather than staying inline. They have to be a single decision: Enter opens *"the highlighted row"*, so a filter computing its list one way while the arrow keys counted another opens the wrong host. That module also owns the out-of-range case, which happens on **every** keystroke as the list shrinks under the highlight — the next key lands on an edge instead of wherever the modulo happens to fall.

`HostList` also backs the SFTP picker and the empty pane slot, so both gain the same search and keyboard.

## Tests

`pickerRows.test.ts`, written first and watched fail (unresolved module, then a real red on the out-of-range case, which is what made me pick "go to the edge" over "wrap from a position that does not exist"):

- empty query keeps every host in order; matching is case-insensitive, trimmed, and runs against the `user@host:port` line the row actually prints;
- the local row leads the list, filters like every other row, and is absent when the picker has no local target;
- `nextRow` steps, wraps at both ends, survives an empty list, and returns to an edge when the list shrank under the highlight.

`vitest run`: 395 passed / 19 files. `tsc --noEmit` and `eslint` clean.

**Not covered by an automated test:** the JSX wiring itself. The client has no component-test setup (vitest only, no Testing Library), so the render path is typechecked and linted but not exercised — worth a click through the `+` menu, the SFTP tab strip and an empty SFTP pane before release.
