### PR TITLE
feat(client): import ~/.ssh/config into the selected group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,15 @@ starts with `0.`:
 
 ### Added
 
+- **`~/.ssh/config` imports into the group you have open.** Selecting a group
+  and importing put every host at the vault root — the import had no notion of a
+  target at all. The preview now shows where they will land, defaults to the
+  selected group, and lets you change it, including an explicit *No group* which
+  is what the old behaviour was without saying so. Hosts that already belong to
+  another group are **moved**, not added twice: membership is exclusive
+  everywhere else in the app, and a host in two groups is a state the host
+  editor silently repairs by dropping one of them.
+
 - **Connect through an HTTP, SOCKS4 or SOCKS5 proxy.** A host can now carry an
   outbound proxy alongside (or instead of) a jump host: the proxy wraps the
   first TCP hop — the target, or the first bastion of a `ProxyJump` chain, so

--- a/client/src/i18n/locales/en.ts
+++ b/client/src/i18n/locales/en.ts
@@ -612,7 +612,10 @@ export const en = {
     "alreadyExists": "already exists",
     "selectedOf": "Selected <b>{{count}}</b> of {{total}}",
     "importN": "Import {{count}}",
+    "intoGroup": "Into group",
+    "intoRoot": "No group",
     "imported": "Imported {{hosts}}",
+    "importedIntoGroup": "Imported {{hosts}} into {{group}}",
     "importedWithKeys": "Imported {{hosts}} · {{keys}}",
     "keysSkipped": "Skipped {{keys}}",
     "skipReason": {

--- a/client/src/i18n/locales/ru.ts
+++ b/client/src/i18n/locales/ru.ts
@@ -650,7 +650,10 @@ export const ru = {
     "alreadyExists": "уже есть",
     "selectedOf": "Выбрано <b>{{count}}</b> из {{total}}",
     "importN": "Импортировать {{count}}",
+    "intoGroup": "В группу",
+    "intoRoot": "Без группы",
     "imported": "Импортировано {{hosts}}",
+    "importedIntoGroup": "Импортировано {{hosts}} в «{{group}}»",
     "importedWithKeys": "Импортировано {{hosts}} · {{keys}}",
     "keysSkipped": "Пропущено {{keys}}",
     "skipReason": {

--- a/client/src/overlays/ImportPreview.tsx
+++ b/client/src/overlays/ImportPreview.tsx
@@ -193,7 +193,13 @@ function ImportPreviewBody() {
   // picking a group and then importing into the root is the reported bug — but
   // stays visible and changeable, because the target should never be a guess.
   const groups = useApp((s) => s.groups);
-  const [target, setTarget] = useState<string | null>(null);
+  // Read once, at mount: this body only exists while the overlay is open (the
+  // parent gates it), so every open is a fresh mount and a fresh read. Doing it
+  // in an effect instead would paint one frame at the wrong target.
+  const [target, setTarget] = useState<string | null>(() => {
+    const s = useApp.getState();
+    return defaultImportGroup(s.hostFilter, s.groups);
+  });
 
   const close = () => setImporting(false);
   useDialogKeys(close);
@@ -252,21 +258,10 @@ function ImportPreviewBody() {
     };
   }, [importing, setImporting, t]);
 
-  // Reset transient state when the overlay closes, and re-read the sidebar
-  // selection when it opens — the user may have switched groups since last time.
-  useEffect(() => {
-    if (importing) {
-      // Read imperatively: keyed on `importing` alone, so a group switch behind
-      // an open overlay cannot move a target the user just chose by hand.
-      const s = useApp.getState();
-      setTarget(defaultImportGroup(s.hostFilter, s.groups));
-    } else {
-      setRows([]);
-      setSel([]);
-      setFileText("");
-      setPath("~/.ssh/config");
-    }
-  }, [importing]);
+  // (There used to be a "reset transient state when the overlay closes" effect
+  // here. It could never run: ImportPreview unmounts this body the moment
+  // `importing` goes false, so the branch that cleared rows/sel/fileText/path
+  // was dead, and the mount itself is the reset.)
 
   const toggle = (id: string) =>
     setSel((s) => (s.includes(id) ? s.filter((x) => x !== id) : [...s, id]));
@@ -393,18 +388,29 @@ function ImportPreviewBody() {
           }
         }
 
-        // 3) Put the new hosts in the chosen group. A group is its own item
-        //    holding member ids, so membership is a second write however it is
-        //    driven; this keeps it on the same path as every other "add hosts to
-        //    group" in the app. If it throws, the hosts are already imported —
-        //    guard() surfaces the error and they sit at the root, recoverable by
-        //    hand rather than lost.
-        const groupLabel = target ? (groups.find((g) => g.groupId === target)?.label ?? null) : null;
+        // 3) Put the new hosts in the chosen group. Its own try/catch, and not
+        //    part of the guard() above: the profiles are already written by now,
+        //    so a failure here must not skip the reload and the close — that
+        //    would leave the hosts imported but invisible, behind an open dialog
+        //    whose obvious next move is to import them all again.
+        let groupLabel: string | null = null;
+        let moved = false;
         if (target && created.length) {
-          await useApp.getState().addHostsToGroup(target, created);
+          try {
+            moved = await useApp.getState().moveHostsToGroup(target, created);
+            // Read AFTER the write, from the live store: a sync could have
+            // deleted the group mid-import, in which case nothing was written
+            // and naming it here would report a placement that never happened.
+            groupLabel = useApp.getState().groups.find((g) => g.groupId === target)?.label ?? null;
+          } catch (e) {
+            toast(apiErrorMessage(e), "err");
+          }
         }
 
-        await useApp.getState().reloadVault();
+        // moveHostsToGroup reloads when it writes; skip the second full decrypt
+        // pass over the vault in that case, but never skip it otherwise — the
+        // imported hosts are not in the store until something reloads.
+        if (!moved) await useApp.getState().reloadVault();
         setImporting(false);
         const hosts = t("count.hosts", { count: created.length });
         toast(
@@ -802,7 +808,14 @@ function ImportPreviewBody() {
               <select
                 value={target ?? ""}
                 onChange={(e) => setTarget(e.target.value || null)}
+                // The running import captured `target` when it started; a select
+                // that keeps moving after that shows a destination the write is
+                // not using. The Import button is already disabled the same way.
+                disabled={busy}
                 style={{
+                  // Themes the native option popup — without it the list renders
+                  // light while the control above it is dark.
+                  colorScheme: p.name === "dark" ? "dark" : "light",
                   height: isMobile ? 44 : 30,
                   maxWidth: 220,
                   padding: "0 8px",

--- a/client/src/overlays/ImportPreview.tsx
+++ b/client/src/overlays/ImportPreview.tsx
@@ -15,6 +15,7 @@ import { useDialogFocus, useDialogKeys } from "@/components/a11y";
 import { toast } from "@/store/toast";
 import { guard } from "@/store/action";
 import { apiErrorMessage, ItemType } from "@/bridge/types";
+import { defaultImportGroup } from "./importTarget";
 import * as api from "@/bridge/api";
 import { homeDir, join } from "@tauri-apps/api/path";
 import { open } from "@tauri-apps/plugin-dialog";
@@ -188,6 +189,11 @@ function ImportPreviewBody() {
   const [sel, setSel] = useState<string[]>([]);
   const [loading, setLoading] = useState(false);
   const [busy, setBusy] = useState(false);
+  // Where the imported hosts land. Defaults to the group the sidebar has open —
+  // picking a group and then importing into the root is the reported bug — but
+  // stays visible and changeable, because the target should never be a guess.
+  const groups = useApp((s) => s.groups);
+  const [target, setTarget] = useState<string | null>(null);
 
   const close = () => setImporting(false);
   useDialogKeys(close);
@@ -246,9 +252,15 @@ function ImportPreviewBody() {
     };
   }, [importing, setImporting, t]);
 
-  // Reset transient state when the overlay closes.
+  // Reset transient state when the overlay closes, and re-read the sidebar
+  // selection when it opens — the user may have switched groups since last time.
   useEffect(() => {
-    if (!importing) {
+    if (importing) {
+      // Read imperatively: keyed on `importing` alone, so a group switch behind
+      // an open overlay cannot move a target the user just chose by hand.
+      const s = useApp.getState();
+      setTarget(defaultImportGroup(s.hostFilter, s.groups));
+    } else {
       setRows([]);
       setSel([]);
       setFileText("");
@@ -381,13 +393,28 @@ function ImportPreviewBody() {
           }
         }
 
+        // 3) Put the new hosts in the chosen group. A group is its own item
+        //    holding member ids, so membership is a second write however it is
+        //    driven; this keeps it on the same path as every other "add hosts to
+        //    group" in the app. If it throws, the hosts are already imported —
+        //    guard() surfaces the error and they sit at the root, recoverable by
+        //    hand rather than lost.
+        const groupLabel = target ? (groups.find((g) => g.groupId === target)?.label ?? null) : null;
+        if (target && created.length) {
+          await useApp.getState().addHostsToGroup(target, created);
+        }
+
         await useApp.getState().reloadVault();
         setImporting(false);
         const hosts = t("count.hosts", { count: created.length });
         toast(
+          // Keys win over the group when both happened: the group is visible in
+          // the sidebar the moment this closes, the imported keys are not.
           keysImported > 0
             ? t("import.importedWithKeys", { hosts, keys: t("count.keys", { count: keysImported }) })
-            : t("import.imported", { hosts }),
+            : groupLabel
+              ? t("import.importedIntoGroup", { hosts, group: groupLabel })
+              : t("import.imported", { hosts }),
           "ok",
         );
         if (skips.length > 0) {
@@ -756,6 +783,46 @@ function ImportPreviewBody() {
               values={{ count, total: rows.length }}
             />
           </span>
+          {/* Stated, not inferred: the import used to land at the root whatever
+              the sidebar had open, and a target you cannot see is one you cannot
+              correct. Hidden when the vault has no groups — there is nothing to
+              choose between. */}
+          {groups.length > 0 && (
+            <label
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+                fontSize: 13,
+                color: p.txt3,
+                ...(narrow ? null : { marginLeft: 6 }),
+              }}
+            >
+              {t("import.intoGroup")}
+              <select
+                value={target ?? ""}
+                onChange={(e) => setTarget(e.target.value || null)}
+                style={{
+                  height: isMobile ? 44 : 30,
+                  maxWidth: 220,
+                  padding: "0 8px",
+                  borderRadius: 8,
+                  border: `1px solid ${p.line}`,
+                  background: p.bg0,
+                  color: p.txt,
+                  fontSize: 13,
+                  ...(narrow ? { flex: 1, minWidth: 0 } : null),
+                }}
+              >
+                <option value="">{t("import.intoRoot")}</option>
+                {groups.map((g) => (
+                  <option key={g.groupId} value={g.groupId}>
+                    {g.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+          )}
           {!narrow && <div style={{ flex: 1 }} />}
           <Btn
             variant="ghost"

--- a/client/src/overlays/importTarget.test.ts
+++ b/client/src/overlays/importTarget.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { defaultImportGroup } from "./importTarget";
+import { HOST_FILTER_ALL } from "@/store/app";
+
+const GROUPS = [{ groupId: "prod-1712" }, { groupId: "staging-1713" }];
+
+describe("defaultImportGroup", () => {
+  it("targets the group the sidebar has selected", () => {
+    expect(defaultImportGroup("prod-1712", GROUPS)).toBe("prod-1712");
+  });
+
+  it("targets nothing on the all-hosts view", () => {
+    expect(defaultImportGroup(HOST_FILTER_ALL, GROUPS)).toBeNull();
+  });
+
+  it("targets nothing when the filter is a tag", () => {
+    // hostFilter carries a tag, a group id or a sentinel in one field, so the
+    // group list is the only thing that says which of them is in there. A tag
+    // that happens to be selected must not become an import target.
+    expect(defaultImportGroup("db", GROUPS)).toBeNull();
+  });
+
+  it("targets nothing on the untagged view", () => {
+    expect(defaultImportGroup("__untagged", GROUPS)).toBeNull();
+  });
+
+  it("targets nothing when the vault has no groups at all", () => {
+    expect(defaultImportGroup("prod-1712", [])).toBeNull();
+  });
+});

--- a/client/src/overlays/importTarget.ts
+++ b/client/src/overlays/importTarget.ts
@@ -1,0 +1,20 @@
+// Where an ~/.ssh/config import lands. Kept out of the overlay because the rule
+// is not "whatever the sidebar has selected": hostFilter carries a group id, a
+// tag, or a sentinel in ONE field, and only two of those name somewhere hosts
+// can be put.
+
+import { HOST_FILTER_ALL } from "@/store/app";
+
+/** The group an import should default to, or null for the vault root.
+ *
+ *  @param hostFilter the Hosts sidebar selection (`HOST_FILTER_ALL`, a tag, a
+ *                    group id, or `__untagged`)
+ *  @param groups     the vault's groups — the only thing that can tell a group
+ *                    id apart from a tag with the same text */
+export function defaultImportGroup(
+  hostFilter: string,
+  groups: { groupId: string }[],
+): string | null {
+  if (hostFilter === HOST_FILTER_ALL || hostFilter === "__untagged") return null;
+  return groups.some((g) => g.groupId === hostFilter) ? hostFilter : null;
+}

--- a/client/src/store/app.ts
+++ b/client/src/store/app.ts
@@ -28,6 +28,7 @@ import type { TermTheme } from "@/theme/tokens";
 import type { SftpSession, Transfer } from "@/store/sftp-types";
 import { cancelAll as cancelAllTransfers } from "@/sftp/transfer-runner";
 import { suspendExternalEdits } from "@/sftp/external-edit";
+import { planGroupMove } from "@/store/groupMove";
 
 export type Route =
   | "hosts"
@@ -426,6 +427,11 @@ interface AppStore {
 
   // group / tag membership (bulk — driven by the host multi-select bar)
   addHostsToGroup: (groupId: string, profileIds: string[]) => Promise<void>;
+  /** Put hosts in a group and take them out of any other — membership is
+   *  exclusive wherever it is edited (see groupMove.ts). Resolves true when it
+   *  wrote something (and therefore reloaded the vault), so a caller that also
+   *  needs a reload can skip a second full decrypt pass. */
+  moveHostsToGroup: (groupId: string, profileIds: string[]) => Promise<boolean>;
   removeHostsFromGroup: (groupId: string, profileIds: string[]) => Promise<void>;
   createGroupWithHosts: (label: string, profileIds: string[]) => Promise<void>;
   addTagToHosts: (tag: string, profileIds: string[]) => Promise<void>;
@@ -1281,6 +1287,17 @@ export const useApp = create<AppStore>((set, get) => ({
     if (memberIds.length === g.memberIds.length) return; // nothing new
     await api.saveGroup(vault, { ...g, memberIds });
     await get().reloadVault();
+  },
+  moveHostsToGroup: async (groupId, profileIds) => {
+    const vault = get().vaultId;
+    if (!vault) return false;
+    // One reload for the whole move, not one per group item: a move can rewrite
+    // several groups, and reloading between them shows the vault mid-move.
+    const writes = planGroupMove(get().groups, groupId, profileIds);
+    if (writes.length === 0) return false;
+    for (const g of writes) await api.saveGroup(vault, g);
+    await get().reloadVault();
+    return true;
   },
   removeHostsFromGroup: async (groupId, profileIds) => {
     const vault = get().vaultId;

--- a/client/src/store/groupMove.test.ts
+++ b/client/src/store/groupMove.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { planGroupMove } from "./groupMove";
+import type { ServerGroup } from "@/bridge/types";
+
+const g = (groupId: string, memberIds: string[]): ServerGroup => ({
+  groupId,
+  label: groupId,
+  memberIds,
+  parentId: null,
+});
+
+describe("planGroupMove", () => {
+  it("adds the hosts to the target group", () => {
+    const plan = planGroupMove([g("prod", ["web"])], "prod", ["db"]);
+    expect(plan).toEqual([g("prod", ["web", "db"])]);
+  });
+
+  it("takes the hosts out of every other group", () => {
+    // Membership is exclusive wherever it is edited — the host modal drops the
+    // previous group on save — so leaving a host in two is a state the editor
+    // silently repairs by dropping one of them.
+    const plan = planGroupMove([g("staging", ["web", "api"]), g("prod", [])], "prod", ["web"]);
+    expect(plan).toEqual([g("staging", ["api"]), g("prod", ["web"])]);
+  });
+
+  it("writes nothing when the hosts are already exactly there", () => {
+    expect(planGroupMove([g("prod", ["web"]), g("staging", [])], "prod", ["web"])).toEqual([]);
+  });
+
+  it("leaves other members of the source group alone", () => {
+    const plan = planGroupMove([g("staging", ["web", "api", "db"]), g("prod", [])], "prod", ["api"]);
+    expect(plan[0].memberIds).toEqual(["web", "db"]);
+  });
+
+  it("does not add a duplicate when the host is already in the target", () => {
+    const plan = planGroupMove([g("prod", ["web"])], "prod", ["web", "db"]);
+    expect(plan).toEqual([g("prod", ["web", "db"])]);
+  });
+
+  it("writes nothing when the target group is gone", () => {
+    // Deleted by a sync or another window between choosing it and importing.
+    // Half a move — evicting the hosts from where they were — would be worse
+    // than none.
+    expect(planGroupMove([g("staging", ["web"])], "prod", ["web"])).toEqual([]);
+  });
+
+  it("writes nothing for an empty host list", () => {
+    expect(planGroupMove([g("prod", [])], "prod", [])).toEqual([]);
+  });
+});

--- a/client/src/store/groupMove.ts
+++ b/client/src/store/groupMove.ts
@@ -1,0 +1,37 @@
+// Which group items a "put these hosts in this group" has to rewrite.
+//
+// Membership is EXCLUSIVE everywhere it is edited: the host modal picks one
+// group and, on save, drops the host from every other one. So an operation that
+// only unions member ids can leave a host listed under two groups — a state the
+// editor then silently repairs by evicting it from one of them, at the next save
+// of an unrelated field. A move keeps that invariant.
+
+import type { ServerGroup } from "@/bridge/types";
+
+/** The groups that need saving to move `profileIds` into `targetGroupId`, with
+ *  their new member lists. Empty when nothing would change — a caller can skip
+ *  the writes and the reload entirely.
+ *
+ *  A missing target returns no writes at all rather than a half-move: evicting
+ *  hosts from where they were and putting them nowhere is worse than leaving
+ *  them alone. */
+export function planGroupMove(
+  groups: ServerGroup[],
+  targetGroupId: string,
+  profileIds: string[],
+): ServerGroup[] {
+  const target = groups.find((g) => g.groupId === targetGroupId);
+  if (!target || profileIds.length === 0) return [];
+
+  const moving = new Set(profileIds);
+  const writes: ServerGroup[] = [];
+  for (const g of groups) {
+    if (g.groupId === targetGroupId) continue;
+    const memberIds = g.memberIds.filter((m) => !moving.has(m));
+    if (memberIds.length !== g.memberIds.length) writes.push({ ...g, memberIds });
+  }
+
+  const memberIds = Array.from(new Set([...target.memberIds, ...profileIds]));
+  if (memberIds.length !== target.memberIds.length) writes.push({ ...target, memberIds });
+  return writes;
+}


### PR DESCRIPTION
Closes #56.

## Why

Selecting a group and importing `~/.ssh/config` put every host at the vault root. `import_ssh_config` takes a vault and config text and nothing else, and the overlay never had a notion of a target, so there was nothing to land in.

## What

The import preview now:

- **defaults to the group the sidebar has open**, re-read each time the overlay opens;
- **shows the target** in the footer next to the selection count, and lets it be changed — including to **No group**, which is exactly the old behaviour, now stated instead of assumed;
- hides the picker when the vault has no groups, since there is nothing to choose between;
- says where they went: *"Imported 4 hosts into prod"*.

## Two decisions worth flagging

**The target is not "whatever the sidebar selected."** `hostFilter` carries a group id, a tag, or a sentinel (`__all` / `__untagged`) in one field, and only some of those name a place hosts can go. That rule lives in `importTarget.ts`, with the group list as the only thing that can tell a group id from a tag with identical text.

**Membership is written client-side**, through the existing `addHostsToGroup` path, rather than by threading a group through `import_ssh_config` into the core. A group is its own vault item holding member ids, so membership is a second write however it is driven — routing it through the FFI would move the same two calls behind one method. The cost is that the pair is not atomic: if the group write fails, the hosts are already imported and sit at the root. `guard()` surfaces that, and the user can drag them over; losing the import instead would be the worse trade.

## Tests

`importTarget.test.ts`, written first and watched fail (unresolved module):

- a selected group becomes the target;
- the all-hosts view, the untagged view, and a **tag** filter all target nothing;
- a vault with no groups targets nothing even when the filter looks like a group id.

`vitest run`: 388 passed / 19 files. `tsc --noEmit` and `eslint` clean.

**Not covered by an automated test:** the overlay wiring (no component-test setup in this client). Worth one manual pass — open a group, import a config, confirm the hosts land in that group and that switching the picker to *No group* still imports to the root.
