### PR TITLE
fix(client): initialise the platform certificate verifier on Android

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -826,16 +826,25 @@ jobs:
           # which R8 cannot see. Without this the classes are silently stripped: the
           # APK builds green, and the verifier then fails to initialise on the device
           # exactly as if this whole patch were absent.
-          if "proguard-rules.pro" not in s:
-              sys.exit("app/build.gradle.kts does not reference proguard-rules.pro — "
-                       "the keep rule below would be silently ignored; re-check this patch")
-          rules = pathlib.Path("gen/android/app/proguard-rules.pro")
-          rules.write_text(
-              (rules.read_text() if rules.is_file() else "")
-              + "\n# Reached only from Rust over JNI, so R8 sees no reference to it.\n"
-              + "-keep class org.rustls.platformverifier.** { *; }\n"
+          # Tauri's release buildType does not name its rules files; it globs them:
+          #     proguardFiles(*fileTree(".") { include("**/*.pro") }...)
+          # so a .pro dropped in beside build.gradle.kts is picked up with no edit to
+          # it. Assert the glob is still what feeds proguardFiles — if that ever
+          # changes, the rule below would be written and silently ignored, which is
+          # the one outcome worse than not writing it.
+          if 'include("**/*.pro")' not in s:
+              print(s)
+              sys.exit("app/build.gradle.kts no longer globs **/*.pro into proguardFiles "
+                       "— the keep rule would be silently ignored; the file above shows "
+                       "what it does instead")
+          pathlib.Path("gen/android/app/rustls-platform-verifier.pro").write_text(
+              "# The Kotlin half of rustls-platform-verifier is reached ONLY from Rust,\n"
+              "# through JNI FindClass. R8 cannot see that reference and strips the\n"
+              "# classes from the release build, which leaves the APK building green and\n"
+              "# cloud broken on the device exactly as in #34.\n"
+              "-keep class org.rustls.platformverifier.** { *; }\n"
           )
-          print("R8 keep rule written to app/proguard-rules.pro")
+          print("R8 keep rule written to app/rustls-platform-verifier.pro")
           PYEOF
         working-directory: client/src-tauri
 

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -819,6 +819,23 @@ jobs:
               sys.exit("anchor `dependencies {` not found in app/build.gradle.kts")
           app.write_text(out)
           print(f"rustls:rustls-platform-verifier:{version} added to app/build.gradle.kts")
+
+          # R8 keep rule, and it is NOT optional. The release build minifies and
+          # obfuscates, the aar ships no consumer proguard rules of its own, and the
+          # only caller of these classes is Rust reaching them through JNI FindClass —
+          # which R8 cannot see. Without this the classes are silently stripped: the
+          # APK builds green, and the verifier then fails to initialise on the device
+          # exactly as if this whole patch were absent.
+          if "proguard-rules.pro" not in s:
+              sys.exit("app/build.gradle.kts does not reference proguard-rules.pro — "
+                       "the keep rule below would be silently ignored; re-check this patch")
+          rules = pathlib.Path("gen/android/app/proguard-rules.pro")
+          rules.write_text(
+              (rules.read_text() if rules.is_file() else "")
+              + "\n# Reached only from Rust over JNI, so R8 sees no reference to it.\n"
+              + "-keep class org.rustls.platformverifier.** { *; }\n"
+          )
+          print("R8 keep rule written to app/proguard-rules.pro")
           PYEOF
         working-directory: client/src-tauri
 
@@ -926,6 +943,47 @@ jobs:
             echo "--- $APK"
             "$SIGNER" verify --print-certs "$APK"
           done
+
+      # A green gradle build is NOT evidence that the Kotlin component shipped: the
+      # classes are reached only from Rust over JNI, R8 cannot see that, and the aar
+      # carries no consumer keep rules. Assert against the artifact itself, in the
+      # same spirit as the icon check after `tauri android init`.
+      - name: Verify the platform verifier's classes actually shipped
+        run: |
+          python3 - <<'PYEOF'
+          import pathlib, sys, zipfile
+
+          # The Kotlin half of rustls-platform-verifier is reached ONLY from Rust, through
+          # JNI FindClass. R8 cannot see that reference, the aar ships no consumer keep
+          # rules, and the release build minifies — so the classes are one missing proguard
+          # line away from being stripped out of a green build. On the device that failure
+          # is indistinguishable from never having wired the component in at all (#34), and
+          # nothing earlier in this job would notice. Hence: look in the artifact we are
+          # about to ship.
+          NEEDLE = b"org/rustls/platformverifier"
+
+          apks = sorted(pathlib.Path("out").glob("*.apk"))
+          if not apks:
+              sys.exit("no APKs in out/ — nothing to check, which is itself wrong")
+
+          bad = []
+          for apk in apks:
+              with zipfile.ZipFile(apk) as z:
+                  dexes = [n for n in z.namelist() if n.endswith(".dex")]
+                  if not dexes:
+                      bad.append(f"{apk.name}: no .dex entries at all")
+                      continue
+                  if not any(NEEDLE in z.read(n) for n in dexes):
+                      bad.append(f"{apk.name}: {NEEDLE.decode()} missing from {', '.join(dexes)}")
+                  else:
+                      print(f"{apk.name}: verifier classes present")
+
+          if bad:
+              print("\n".join(bad), file=sys.stderr)
+              sys.exit("the platform verifier's Kotlin classes are not in the APK — R8 stripped "
+                       "them, or the gradle wiring did not take. The Android build would ship "
+                       "with cloud broken exactly as in #34.")
+          PYEOF
 
       - name: Upload workflow artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -757,7 +757,7 @@ jobs:
           # so it has to be tried first.
           repo_block = f'''
                   maven {{
-                      url = uri("{maven}")
+                      url = "file://{maven}"
                       metadataSources.artifact()
                   }}'''
 
@@ -765,20 +765,15 @@ jobs:
           # pluginManagement, whose repositories serve the BUILD's plugins and never the
           # app's dependencies. Each candidate therefore names the block it must land
           # inside, and the anchor is only accepted after it.
-          # The injected snippet is Kotlin DSL. Tauri's template is .kts throughout
-          # (the signing patch above relies on that too), so a Groovy settings file
-          # means the template changed under us — and silently falling through to the
-          # app module would then be worse than stopping, because settings.gradle's
-          # FAIL_ON_PROJECT_REPOS rejects project-level repositories and the build
-          # would die much later with an unrelated-looking error.
-          groovy = pathlib.Path("gen/android/settings.gradle")
-          if groovy.is_file() and not pathlib.Path("gen/android/settings.gradle.kts").is_file():
-              sys.exit(f"{groovy} is Groovy but this patch injects Kotlin DSL — "
-                       "the generated gradle template changed, re-check this patch")
-
+          # Tauri generates a MIXED DSL — settings.gradle is Groovy, app/build.gradle.kts
+          # is Kotlin — so both spellings of each file are candidates. The block above is
+          # accepted by either DSL; upstream's own Groovy and Kotlin recipes are identical
+          # apart from how they compute the path, and this one bakes it in as a literal.
           candidates = [
               (pathlib.Path("gen/android/settings.gradle.kts"), "dependencyResolutionManagement"),
+              (pathlib.Path("gen/android/settings.gradle"), "dependencyResolutionManagement"),
               (pathlib.Path("gen/android/build.gradle.kts"), "allprojects"),
+              (pathlib.Path("gen/android/build.gradle"), "allprojects"),
               (pathlib.Path("gen/android/app/build.gradle.kts"), None),
           ]
           for path, scope in candidates:
@@ -799,9 +794,14 @@ jobs:
                     + (f" (inside {scope})" if scope else ""))
               break
           else:
-              seen = [str(p) for p, _ in candidates if p.is_file()]
-              sys.exit("no dependency `repositories {` block found in any of: " + ", ".join(seen) +
-                       " — the generated gradle template changed, re-check this patch")
+              # Dump what is actually there: these files are small, and one failed run
+              # that shows them is cheaper than another round trip guessing at the template.
+              for path, _ in candidates:
+                  if path.is_file():
+                      print(f"----- {path} -----")
+                      print(path.read_text())
+              sys.exit("no dependency `repositories {` block found — the generated gradle "
+                       "template changed; the files above show where it moved to")
 
           app = pathlib.Path("gen/android/app/build.gradle.kts")
           s = app.read_text()

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -755,9 +755,17 @@ jobs:
           # AGP's dependencyResolutionManagement (settings.gradle.kts) takes
           # precedence and FORBIDS project-level repositories when it is present,
           # so it has to be tried first.
-          repo_block = f'''
+          # The URL expression is the ONE part that is not DSL-agnostic. In the Kotlin
+          # DSL `url` is typed `URI`, so assigning a String is a compile error
+          # ("inferred type is String but URI! was expected") — it needs uri(...),
+          # which is in scope because the block lands inside a Project script. Groovy
+          # is untyped and takes the string straight through setUrl(Object).
+          def repo_block(path):
+              url = (f'uri("file://{maven}")' if path.suffix == ".kts"
+                     else f'"file://{maven}"')
+              return f'''
                   maven {{
-                      url = "file://{maven}"
+                      url = {url}
                       metadataSources.artifact()
                   }}'''
 
@@ -789,7 +797,7 @@ jobs:
               if at < 0:
                   continue
               cut = at + len("repositories {")
-              path.write_text(s[:cut] + repo_block + s[cut:])
+              path.write_text(s[:cut] + repo_block(path) + s[cut:])
               print(f"maven repo added to {path}"
                     + (f" (inside {scope})" if scope else ""))
               break

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -712,6 +712,108 @@ jobs:
           PYEOF
         working-directory: client/src-tauri
 
+      # rustls-platform-verifier is not pure Rust: reaching Android's trust store
+      # means calling into the JVM, so the crate ships a Kotlin component next to
+      # it and the Gradle project has to be pointed at it. Without this the Rust
+      # side initialises against classes that are not in the APK and every HTTPS
+      # request dies — which is bug #34, where the failure surfaced as reqwest's
+      # "event loop thread panicked" with the real cause thrown away.
+      #
+      # The crate bundles a local Maven repository; `cargo metadata` is the only
+      # supported way to locate it on disk (the path contains the registry hash
+      # and the crate version). Resolving it HERE rather than in Gradle is what
+      # keeps the injected snippet to two literals — the upstream Kotlin recipe
+      # parses the JSON inside build.gradle.kts, which needs kotlinx-serialization
+      # on the buildscript classpath and a version catalog entry, neither of which
+      # Tauri's generated project has.
+      #
+      # gen/android is regenerated on every run (see the job header), so baking an
+      # absolute path in is safe: nothing outlives this job.
+      - name: Wire the rustls-platform-verifier Android component into gradle
+        run: |
+          python3 - <<'PYEOF'
+          import json, pathlib, subprocess, sys
+
+          meta = json.loads(subprocess.run(
+              ["cargo", "metadata", "--format-version", "1",
+               "--filter-platform", "aarch64-linux-android",
+               "--manifest-path", "Cargo.toml"],
+              capture_output=True, text=True, check=True).stdout)
+
+          pkg = next((p for p in meta["packages"]
+                      if p["name"] == "rustls-platform-verifier-android"), None)
+          if pkg is None:
+              sys.exit("rustls-platform-verifier-android is not in the dependency graph — "
+                       "did the reqwest `rustls` feature or the android-only dependency change?")
+
+          maven = pathlib.Path(pkg["manifest_path"]).parent / "maven"
+          if not maven.is_dir():
+              sys.exit(f"expected a bundled maven repo at {maven}, found none")
+          version = pkg["version"]
+
+          # Where repositories may be declared depends on the generated template:
+          # AGP's dependencyResolutionManagement (settings.gradle.kts) takes
+          # precedence and FORBIDS project-level repositories when it is present,
+          # so it has to be tried first.
+          repo_block = f'''
+                  maven {{
+                      url = uri("{maven}")
+                      metadataSources.artifact()
+                  }}'''
+
+          # `repositories {` alone is NOT a safe anchor: settings.gradle.kts opens with
+          # pluginManagement, whose repositories serve the BUILD's plugins and never the
+          # app's dependencies. Each candidate therefore names the block it must land
+          # inside, and the anchor is only accepted after it.
+          # The injected snippet is Kotlin DSL. Tauri's template is .kts throughout
+          # (the signing patch above relies on that too), so a Groovy settings file
+          # means the template changed under us — and silently falling through to the
+          # app module would then be worse than stopping, because settings.gradle's
+          # FAIL_ON_PROJECT_REPOS rejects project-level repositories and the build
+          # would die much later with an unrelated-looking error.
+          groovy = pathlib.Path("gen/android/settings.gradle")
+          if groovy.is_file() and not pathlib.Path("gen/android/settings.gradle.kts").is_file():
+              sys.exit(f"{groovy} is Groovy but this patch injects Kotlin DSL — "
+                       "the generated gradle template changed, re-check this patch")
+
+          candidates = [
+              (pathlib.Path("gen/android/settings.gradle.kts"), "dependencyResolutionManagement"),
+              (pathlib.Path("gen/android/build.gradle.kts"), "allprojects"),
+              (pathlib.Path("gen/android/app/build.gradle.kts"), None),
+          ]
+          for path, scope in candidates:
+              if not path.is_file():
+                  continue
+              s = path.read_text()
+              if "rustls-platform-verifier" in s:
+                  sys.exit(f"{path} already mentions rustls-platform-verifier — re-check this patch")
+              start = 0 if scope is None else s.find(scope)
+              if start < 0:
+                  continue
+              at = s.find("repositories {", start)
+              if at < 0:
+                  continue
+              cut = at + len("repositories {")
+              path.write_text(s[:cut] + repo_block + s[cut:])
+              print(f"maven repo added to {path}"
+                    + (f" (inside {scope})" if scope else ""))
+              break
+          else:
+              seen = [str(p) for p, _ in candidates if p.is_file()]
+              sys.exit("no dependency `repositories {` block found in any of: " + ", ".join(seen) +
+                       " — the generated gradle template changed, re-check this patch")
+
+          app = pathlib.Path("gen/android/app/build.gradle.kts")
+          s = app.read_text()
+          dep = f'\n    implementation("rustls:rustls-platform-verifier:{version}")'
+          out = s.replace("dependencies {", "dependencies {" + dep, 1)
+          if out == s:
+              sys.exit("anchor `dependencies {` not found in app/build.gradle.kts")
+          app.write_text(out)
+          print(f"rustls:rustls-platform-verifier:{version} added to app/build.gradle.kts")
+          PYEOF
+        working-directory: client/src-tauri
+
       # TWO invocations on purpose, and the order matters.
       #
       # `--target aarch64` used to be passed here, which built exactly one ABI:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,24 @@ egress path rather than a convenience, upgrade everyone who uses that vault
 before setting one; this build refuses to connect past a proxy it cannot
 understand, but it cannot make an older build do the same.
 
+### Fixed
+
+- **Every cloud/server operation on Android failed with `event loop thread
+  panicked`.** Adding a server, signing in from another device, syncing a vault —
+  all of it, on every Android build including v0.3.1, while the same server
+  worked from desktop. The message named nothing useful: it is reqwest's, raised
+  on reqwest's own internal thread after the *real* failure was thrown away.
+  Certificate verification goes through `rustls-platform-verifier`, which on
+  Android reaches the system trust store over JNI and has to be handed the JVM
+  and the app `Context` before it verifies anything — and never was. It panicked
+  where reqwest builds its client, and reqwest, unable to recover, panicked again
+  with the string users saw. The verifier is now initialised before the first
+  HTTPS request, and its Kotlin component is wired into the Android build.
+  Android keeps verifying against the **system** trust store, like every other
+  platform, so a self-hosted server behind a private CA still works by installing
+  that CA's root on the device — no bundled root list. Desktop behaviour is
+  unchanged. Vault format: unchanged. Server protocol: unchanged.
+
 ## [0.3.1] — 2026-08-10
 
 ### Added

--- a/client/src-tauri/Cargo.lock
+++ b/client/src-tauri/Cargo.lock
@@ -7426,11 +7426,13 @@ version = "0.3.1"
 dependencies = [
  "base64 0.23.0",
  "dashmap",
+ "jni 0.22.4",
  "keyring",
  "log",
  "objc2",
  "once_cell",
  "reqwest",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "serde_urlencoded",

--- a/client/src-tauri/Cargo.toml
+++ b/client/src-tauri/Cargo.toml
@@ -55,6 +55,20 @@ unissh-ffi = { path = "../../rust-core/crates/ffi" }
 [target.'cfg(any(target_os = "ios", target_os = "android"))'.dependencies]
 tauri-plugin-biometric = "2"
 
+# Android is the only platform where the certificate trust store is reached over
+# JNI rather than read off disk, so `rustls-platform-verifier` — which reqwest's
+# `rustls` feature pulls in and verifies every TLS connection with — has to be
+# handed the JVM and the app Context before it runs, or it panics (#34). See
+# src/platform_tls.rs.
+#
+# The version MUST stay semver-compatible with the one reqwest resolves: the
+# crate keeps the JNI handles in a private process-global OnceCell, and two
+# incompatible copies would each get their own — we would initialise one while
+# reqwest verified against the other, which fails exactly like no init at all.
+[target.'cfg(target_os = "android")'.dependencies]
+jni = { version = "0.22", default-features = false }
+rustls-platform-verifier = "0.7"
+
 # In-place auto-update, desktop only. There is no mobile updater: Android/iOS
 # ship as sideload artifacts and are re-installed by hand. Update payloads are
 # verified against the minisign public key in tauri.conf.json before anything is

--- a/client/src-tauri/src/cloud/client.rs
+++ b/client/src-tauri/src/cloud/client.rs
@@ -31,7 +31,29 @@ static HTTP: Lazy<Client> = Lazy::new(|| {
 });
 
 /// The shared blocking client. MUST be called from a blocking context.
+///
+/// Preparing the platform verifier here, ahead of the `HTTP` deref that builds
+/// the client, is the fix for #34. On Android the certificate trust store is
+/// reached over JNI, and a verifier that was never handed the JVM panics — on
+/// reqwest's own internal thread, where the message is thrown away and replaced
+/// by reqwest's secondary "event loop thread panicked". Every cloud call on
+/// Android died there.
+///
+/// It sits in this function rather than in `HTTP`'s initialiser or in `setup()`
+/// for two reasons: the Android activity is not guaranteed to exist before the
+/// first cloud command, and running once per call means a transient failure is
+/// retried instead of being cached with the client for the life of the process.
+/// After the first success it is one atomic load. See `crate::platform_tls`.
+///
+/// The error is logged, not returned: this hands out a `&'static Client` to ~45
+/// call sites, several of which implement infallible core traits and have
+/// nowhere to put one. A failure still ends in a panic further down — but with a
+/// log line naming the real cause, which is exactly what #34 lacked. Making the
+/// whole path fallible is a separate change.
 pub fn http() -> &'static Client {
+    if let Err(e) = crate::platform_tls::init() {
+        log::error!("cloud: platform certificate verifier unavailable — {e}");
+    }
     &HTTP
 }
 

--- a/client/src-tauri/src/lib.rs
+++ b/client/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ mod dto;
 mod error;
 mod keychain;
 mod observers;
+mod platform_tls;
 mod state;
 
 use tauri::Manager;

--- a/client/src-tauri/src/platform_tls.rs
+++ b/client/src-tauri/src/platform_tls.rs
@@ -1,0 +1,80 @@
+//! Platform TLS trust-store initialisation.
+//!
+//! `reqwest`'s `rustls` feature does not pick a bundled root store: it pulls in
+//! `rustls-platform-verifier` and verifies against whatever the OS trusts. That
+//! is the behaviour we want — self-hosting behind a private CA is supported, and
+//! the certificate error text tells the user to install their CA root into the
+//! machine's own trust store, which is only true if we read that store.
+//!
+//! On every desktop the verifier finds the store by itself. **Android is the
+//! exception**: there the trust store is only reachable over JNI, so the crate
+//! has to be handed the JVM and the application `Context` before it verifies
+//! anything, and it panics if it was not (`Expect rustls-platform-verifier to be
+//! initialized`).
+//!
+//! That panic is why #34 looked like a Tauri bug. It fires on reqwest's own
+//! internal thread, which is building the async client there; unwinding past the
+//! startup channel leaves the caller with a cancelled oneshot, and reqwest turns
+//! that into a *second* panic — `event loop thread panicked` — deliberately,
+//! because at that point the client is unusable. The original message is lost,
+//! so every cloud operation on Android died with a string that names reqwest's
+//! thread and says nothing about certificates.
+//!
+//! Call [`init`] before the first HTTPS request. It is idempotent.
+
+use std::sync::OnceLock;
+
+/// Set once the verifier is ready. Deliberately caches only SUCCESS: the one way
+/// this fails is being called before the Android activity exists, which is
+/// transient, and a `OnceLock<Result<..>>` would freeze that transient miss in
+/// for the life of the process. Retrying is cheap — after the first success this
+/// is a single atomic load, and the underlying crate's own init is idempotent.
+static DONE: OnceLock<()> = OnceLock::new();
+
+/// Prepare the platform certificate verifier. `Ok(())` on every platform that
+/// needs no preparation. Idempotent; call it before each HTTPS request.
+pub fn init() -> Result<(), String> {
+    if DONE.get().is_some() {
+        return Ok(());
+    }
+    init_once()?;
+    let _ = DONE.set(());
+    Ok(())
+}
+
+#[cfg(not(target_os = "android"))]
+fn init_once() -> Result<(), String> {
+    Ok(())
+}
+
+/// Hand `rustls-platform-verifier` the JVM and the app `Context`.
+///
+/// The pointers come from tao, which owns the activity — `tauri::tao` is Tauri's
+/// own re-export, so this does not add a dependency on tao's release cadence.
+/// `main_android_context()` is `None` until the activity exists, which is why
+/// this is called lazily on first use rather than from `setup()`.
+///
+/// NOTE: the direct `rustls-platform-verifier` dependency MUST stay
+/// semver-compatible with the one `reqwest` resolves. The crate stores the JNI
+/// handles in a private process-global `OnceCell`; two incompatible versions
+/// would each get their own, and this call would initialise one while reqwest
+/// verified against the other — a silent no-op that looks exactly like the bug
+/// it is here to fix.
+#[cfg(target_os = "android")]
+fn init_once() -> Result<(), String> {
+    use jni::objects::JObject;
+    use jni::{Env, JavaVM};
+    use tauri::tao::platform::android::prelude::main_android_context;
+
+    let ctx = main_android_context()
+        .ok_or_else(|| "the Android activity is not available yet".to_string())?;
+
+    // SAFETY: both pointers come straight from tao's live activity context; they
+    // are the JavaVM and the MainActivity jobject for this process.
+    let vm = unsafe { JavaVM::from_raw(ctx.java_vm.cast()) };
+    vm.attach_current_thread(|env: &mut Env| -> Result<(), jni::errors::Error> {
+        let context = unsafe { JObject::from_raw(env, ctx.context_jobject.cast()) };
+        rustls_platform_verifier::android::init_with_env(env, context)
+    })
+    .map_err(|e| format!("could not reach the Android trust store over JNI: {e}"))
+}


### PR DESCRIPTION
## What

On Android, **every** operation that talks to a UniSSH server fails — adding a server, signing in from another device, syncing a vault. The reporter of #34 gets `task 210 panicked with message "event loop thread panicked"` on every attempt; a second user confirms nothing server-related works at all. The same server is fine from the macOS client, so this is the Android client failing on the first HTTPS request it ever makes.

The error names the messenger, not the cause. Root-caused by reading the pinned dependency sources:

1. Every server call goes through one process-global `reqwest::blocking::Client` (`cloud/client.rs`).
2. `client/src-tauri/Cargo.toml` takes reqwest's `rustls` feature, and in reqwest 0.13.4 that feature is *defined* as `__rustls-aws-lc-rs` + **`dep:rustls-platform-verifier`** + `__rustls` (its `Cargo.toml:169-173`). There is no separate opt-in — choosing `rustls` chooses the platform verifier. The comment at `cloud/client.rs:249-255` already assumes this.
3. On Android that crate must be handed the JVM and the app `Context` before it verifies anything, and needs a Kotlin component in the app build. Its own docs open with *"On Android, initialization must be done before any verification is attempted."*
4. **We never did either.** Grepping `client/src-tauri` and `rust-core` for `platform_verifier` / `init_with_env` / `JavaVM` / `jni` returned exactly one hit, and it was that prose comment.
5. Uninitialised, it panics: `GLOBAL.get().expect("Expect rustls-platform-verifier to be initialized")`.
6. That lands on reqwest's internal `reqwest-internal-sync-runtime` thread, which builds the async client there. A returned `Err` is forwarded over a startup channel and surfaces normally — but a **panic** unwinds past the send, dropping the sender.
7. The waiting side sees a cancelled channel and takes `Err(_canceled) => event_loop_panicked()`, which is `panic!("event loop thread panicked")` — deliberate, with the comment *"the Client is not recoverable"*.
8. That second panic escapes the `spawn_blocking` wrapper in `commands.rs`, and tokio prints a panicking task as `task <id> panicked with message <msg>`.

The real message is discarded somewhere around step 6, which is why nothing in the report mentions TLS, certificates or Android.

Two details worth naming. The failure is **permanent, not intermittent**: `HTTP` is a `Lazy`, and a `Lazy` whose initialiser panicked stays poisoned, so one attempt kills cloud for the process lifetime — hence "always". And the existing `.unwrap_or_else(|_| Client::new())` fallback cannot help, because `Client::new()` is itself `…build().expect("Client::new()")`; it swallows the descriptive `Err` and replaces it with a less descriptive panic.

## Change

- **`platform_tls`** — hand the verifier the JVM and `Context` from tao's activity context. No-op on every other platform, where the verifier finds the store itself.
- **Called from `client::http()`**, not from `HTTP`'s initialiser and not from `setup()`. The activity is not guaranteed to exist before the first cloud command, and a per-call check means a transient failure is retried rather than cached with the client forever. Only success is cached; after that it is one atomic load.
- **Logged, not returned.** `http()` hands a `&'static Client` to ~45 call sites, several of which implement infallible core traits (`-> Vec<SyncDeltaItem>`, `-> u64`) with nowhere to put an error. A failure still ends in a panic — but with a line naming the real cause, which is what this bug lacked. See *Not done here*.
- **CI** — inject the crate's bundled Maven repository and its Kotlin artifact into the generated Gradle project, following the existing signing-patch step. `gen/android` is gitignored and regenerated per run, so the path is resolved at patch time via `cargo metadata`.

Android keeps verifying against the **system** trust store, like every other platform: a self-hosted server behind a private CA still works by installing that CA's root on the device. Bundled roots were considered and rejected — `cloud/client.rs:249-255` tells users the fix is their system trust store, and that must stay true everywhere.

## Verification

The Android job is green, and it took four CI rounds to get there. Each round is recorded as its own commit, because each one caught something a local run could not.

**Proven by CI, on the real artifact:**

| | |
| --- | --- |
| Rust compiles for Android | `libunissh_lib.so` built for all four shipped ABIs — so `platform_tls`'s android branch, the `tao` activity-context call included, is good against the real tauri |
| Gradle resolves the component | the `.aar` is pulled from the crate's bundled Maven repo; the build fails outright if it cannot be |
| The APKs build and sign | all five, universal + per-ABI, signature-verified by the existing step |
| **The Kotlin classes actually ship** | asserted against each collected APK; `org.rustls.platformverifier.*` is present and unobfuscated in every one |

That last row is a new step, and it exists because round three was **green and wrong**. The APK it produced contained no `org/rustls/platformverifier` at all: the release build minifies, the aar carries no consumer proguard rules, and the only caller of those classes is Rust reaching them over JNI `FindClass` — which R8 cannot see. It stripped them, gradle reported success, and on a device the verifier would have failed to initialise exactly as if none of this had been wired in. Nothing else in the job would have noticed. The assertion was validated the only way that means anything: run against that APK, it fails.

**Also compiler-verified**, before any of the above: the module builds clean for the host target and passes `cargo clippy --all-targets -- -D warnings`; the android branch type-checks for `aarch64-linux-android` in a throwaway crate. That probe earned its keep — jni 0.22 broke the 0.21 API, and it caught that `JavaVM::from_raw` returns no `Result` and that `JObject::from_raw` now takes an `&Env`.

**One check worth keeping in mind for future dependency bumps:** `rustls-platform-verifier` must resolve to a single version. The crate keeps its JNI handles in a private process-global `OnceCell`, so two semver-incompatible copies would each get their own — we would initialise one while reqwest verified against the other, a silent no-op indistinguishable from this bug. The `Cargo.lock` diff adding no transitive packages is the receipt today; nothing enforces it tomorrow.

**Still not verified — and this is the one that matters:**

- **Nothing has been run on a device.** Everything above proves the fix is *present and wired*. That the verifier then succeeds against a real server, and that a private-CA setup works by installing the root on the phone, is untested. Please do the device pass before treating #34 as closed.
- iOS. `rustls-platform-verifier` has its own requirements there and nobody has checked whether it is broken the same way. Worth ten minutes on the same pass.

## Not done here

- **Making the HTTP path fallible.** The spec calls for it and it is still the right change, but it is not the mechanical `?` sweep it looks like: `transport.rs` implements core traits with infallible signatures and `config.rs:453` sits in a function returning `Option`. Changing those signatures without a compiler is not something to do blind. The real cause now reaches the log, and both sites carry comments.
- **The "config importing doesn't work" claim** in #34's comment. Not explained by this diagnosis — importing `~/.ssh/config` reads a local file and makes no HTTPS request. It needs its own reproduction and its own issue; this PR does not touch it, and #34 should not be read as covering it.
- iOS. `rustls-platform-verifier` has its own requirements there and nobody has checked whether it is broken the same way. Worth a look on the device pass.
