### PR TITLE
feat(hosts): drag a host onto a group to file it there

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,21 @@ starts with `0.`:
 
 ### Added
 
+- **Hosts can be dragged into a group.** Filing a host was menu-only — open the
+  overflow menu, find "Move to group", pick the target, and repeat for every
+  host you wanted moved — while every other rearrangeable list in UniSSH is
+  dragged. Pick up a host card or row and drop it on a group in the sidebar and
+  it moves there, leaving whatever group it was in; drag one host out of a
+  multi-selection and the whole selection goes with it, drag one that is *not*
+  selected and only that host moves. The group under the pointer is ringed so
+  the destination is visible before the release, Escape abandons the drag, and a
+  drop on anything that is not a group — the toolbar, a tag chip, empty space —
+  does nothing and says nothing. Dropping a host on the group it is already in
+  writes nothing at all, so the list does not flicker for a no-op.
+
+  The menu path is untouched, and it stays the only path on a phone, where a
+  vertical drag is a scroll.
+
 - **The host picker has a search box and a keyboard.** The `+` in the terminal
   and SFTP tab strips only offered a search past six saved hosts, so anyone with
   fewer never saw one; it now appears for any non-empty list. The list also

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,11 @@ starts with `0.`:
   writes nothing at all, so the list does not flicker for a no-op.
 
   The menu path is untouched, and it stays the only path on a phone, where a
-  vertical drag is a scroll.
+  vertical drag is a scroll. It also gains **Copy address**: text on a
+  `draggable` element cannot be selected, so dragging a card took away the one
+  way there was of getting a host's address off this screen. The menu item is
+  better than what it replaces — it works in the list layout too, where the
+  address is ellipsised, and it does not depend on hitting 12px of mono type.
 
 - **The host picker has a search box and a keyboard.** The `+` in the terminal
   and SFTP tab strips only offered a search past six saved hosts, so anyone with

--- a/client/src/i18n/locales/en.ts
+++ b/client/src/i18n/locales/en.ts
@@ -531,6 +531,7 @@ export const en = {
     "searchPlaceholder": "Filter by name, address or tag",
     "connect": "Connect",
     "menu": {
+      "copyAddress": "Copy address",
       "addToGroup": "Add to group\u2026",
       "manageGroups": "Manage groups\u2026"
     },
@@ -598,6 +599,7 @@ export const en = {
       "addedTag": "Tagged #{{name}}",
       "removedTag": "Removed #{{name}}"
     },
+    "addressCopied": "Address copied",
     "railHost": "Host",
     "railSessions": "Sessions",
     "selectHost": "Select a host",

--- a/client/src/i18n/locales/en.ts
+++ b/client/src/i18n/locales/en.ts
@@ -593,6 +593,7 @@ export const en = {
       "newTagPlaceholder": "New tag…",
       "nothingToRemove": "Selected hosts aren't in any group or tag.",
       "addedToGroup": "Added to {{name}}",
+      "movedToGroup": "Moved to {{name}}",
       "removedFromGroup": "Removed from {{name}}",
       "addedTag": "Tagged #{{name}}",
       "removedTag": "Removed #{{name}}"

--- a/client/src/i18n/locales/ru.ts
+++ b/client/src/i18n/locales/ru.ts
@@ -569,6 +569,7 @@ export const ru = {
     "searchPlaceholder": "Поиск по имени, адресу или тегу",
     "connect": "Подключить",
     "menu": {
+      "copyAddress": "Скопировать адрес",
       "addToGroup": "В группу\u2026",
       "manageGroups": "Управление группами\u2026"
     },
@@ -636,6 +637,7 @@ export const ru = {
       "addedTag": "Добавлен тег #{{name}}",
       "removedTag": "Убран тег #{{name}}"
     },
+    "addressCopied": "Адрес скопирован",
     "railHost": "Хост",
     "railSessions": "Сессии",
     "selectHost": "Выберите хост",

--- a/client/src/i18n/locales/ru.ts
+++ b/client/src/i18n/locales/ru.ts
@@ -631,6 +631,7 @@ export const ru = {
       "newTagPlaceholder": "Новый тег…",
       "nothingToRemove": "Выбранные хосты не состоят ни в одной группе или теге.",
       "addedToGroup": "Добавлено в «{{name}}»",
+      "movedToGroup": "Перенесено в «{{name}}»",
       "removedFromGroup": "Убрано из «{{name}}»",
       "addedTag": "Добавлен тег #{{name}}",
       "removedTag": "Убран тег #{{name}}"

--- a/client/src/shell/Shell.tsx
+++ b/client/src/shell/Shell.tsx
@@ -2,7 +2,7 @@
 // switcher, nav. Faithful port of app-shell.jsx + app-main.jsx title slots,
 // fed by real store data.
 
-import React, { useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { usePalette, useTheme } from "@/theme/ThemeProvider";
 import { MONO } from "@/theme/tokens";
@@ -11,12 +11,13 @@ import { FlatAvatar, SyncBadge } from "@/components/mono";
 import { useExternalEdits } from "@/sftp/external-edit";
 import { useMenu } from "@/components/a11y";
 import { useApp, HOST_FILTER_ALL } from "@/store/app";
+import { hostDrag } from "@/support/hostDrag";
 import { isMac, isTauri } from "@/bridge/platform";
 import { useFullscreen, useMaximized } from "@/shell/WindowChrome";
 import { useNarrow } from "@/store/responsive";
 import type { Route } from "@/store/app";
 import { useCtx } from "@/store/ctx";
-import { type VaultInfo } from "@/bridge/types";
+import { apiErrorMessage, type VaultInfo } from "@/bridge/types";
 import { serverShortLabel, vaultLoc, vaultServer } from "@/bridge/vaults";
 import { useTranslation, tDyn } from "@/i18n";
 
@@ -314,6 +315,7 @@ function NavItem({
   sub,
   onClick,
   badge,
+  onDropHosts,
 }: {
   icon?: IconName;
   label: string;
@@ -322,6 +324,10 @@ function NavItem({
   sub?: boolean;
   onClick?: () => void;
   badge?: string;
+  /** Makes this item a drop target for hosts dragged off the Hosts screen.
+   *  Only the group items pass it: "All hosts" is not a group, and dropping a
+   *  host on it would mean un-grouping — a menu action, not this gesture. */
+  onDropHosts?: (profileIds: string[]) => void;
 }) {
   const p = usePalette();
   // Hover fill is React state, not an imperative e.currentTarget.style mutation:
@@ -329,12 +335,51 @@ function NavItem({
   // reconciler sees background unchanged ("transparent" both renders) and leaves a
   // stale old-theme fill until the next mouse event. Declaring it keeps it in sync.
   const [hover, setHover] = useState(false);
+  // Lit only while a host drag is actually over THIS item, so the affordance
+  // says "the drop lands here" and not merely "a drag is happening".
+  const [dropOver, setDropOver] = useState(false);
+  // `dragleave` is not fired for a drag that ENDS over the item — press Escape
+  // with the pointer here and the ring would stay lit on a drop that never
+  // happened. `dragend` bubbles to the window for every ending there is.
+  useEffect(() => {
+    if (!dropOver) return;
+    const off = () => setDropOver(false);
+    window.addEventListener("dragend", off);
+    return () => window.removeEventListener("dragend", off);
+  }, [dropOver]);
+  const dragProps = onDropHosts
+    ? {
+        onDragOver: (e: React.DragEvent) => {
+          // No payload = not our drag (a file from the desktop, a link): leave it
+          // unhandled so the item stays inert rather than pretending to accept it.
+          if (hostDrag.get().length === 0) return;
+          e.preventDefault();
+          e.dataTransfer.dropEffect = "move";
+          setDropOver(true);
+        },
+        // Crossing into the item's own icon/label fires dragleave on the item
+        // (relatedTarget = the child), which without this guard blinks the ring
+        // off and on as the pointer travels across it.
+        onDragLeave: (e: React.DragEvent) => {
+          if (e.currentTarget.contains(e.relatedTarget as Node)) return;
+          setDropOver(false);
+        },
+        onDrop: (e: React.DragEvent) => {
+          e.preventDefault();
+          setDropOver(false);
+          const ids = hostDrag.get();
+          hostDrag.clear();
+          if (ids.length > 0) onDropHosts(ids);
+        },
+      }
+    : null;
   return (
     <button
       onClick={onClick}
       aria-current={active ? "page" : undefined}
       onMouseEnter={() => setHover(true)}
       onMouseLeave={() => setHover(false)}
+      {...dragProps}
       style={{
         ...BTN_RESET,
         display: "flex",
@@ -349,9 +394,19 @@ function NavItem({
         cursor: "pointer",
         // Active = neutral fill + a 2.5px accent edge tick (the reference tick alone
         // read as almost invisible); hover = the same faint fill, no tick.
-        background: active || hover ? p.bg2 : "transparent",
+        background: active || hover || dropOver ? p.bg2 : "transparent",
         color: active ? p.txt : p.txt2,
-        boxShadow: active ? `inset 2.5px 0 0 ${p.accent}` : "none",
+        // Drop target = the same accent in a lighter weight: a hairline ring
+        // instead of the solid edge tick, so "the drop lands here" is legible at
+        // a glance yet never reads as "you are here" — the two are visible side
+        // by side while the drag is over a group that isn't the current filter.
+        boxShadow:
+          [
+            active ? `inset 2.5px 0 0 ${p.accent}` : null,
+            dropOver ? `inset 0 0 0 1px ${p.accent}` : null,
+          ]
+            .filter(Boolean)
+            .join(", ") || "none",
         fontSize: 13,
         fontWeight: active ? 600 : 500,
       }}
@@ -831,7 +886,22 @@ export function Sidebar({
   const terminals = useApp((s) => s.terminals);
   const tunnels = useApp((s) => s.tunnels);
   const hostFilter = useApp((s) => s.hostFilter);
+  const moveHostsToGroup = useApp((s) => s.moveHostsToGroup);
   const ctx = useCtx();
+
+  // Drop of hosts dragged off the Hosts screen. The move itself is the store's,
+  // unchanged — drag adds no membership rules of its own, so it and the menu
+  // can never disagree about what filing a host means. A false return is
+  // "nothing would change" (dropped on the group they are already in, or on a
+  // group another window just deleted): no write, no reload, and no toast for a
+  // move that didn't happen.
+  const dropHostsOn = (groupId: string, label: string) => (profileIds: string[]) => {
+    void moveHostsToGroup(groupId, profileIds)
+      .then((moved) => {
+        if (moved) ctx.toast(t("hosts.bulk.movedToGroup", { name: label }), "ok");
+      })
+      .catch((e) => ctx.toast(apiErrorMessage(e), "err"));
+  };
 
   if (!wide || collapsed) return <SidebarRail onExpand={wide ? onToggleCollapse : undefined} />;
 
@@ -893,6 +963,7 @@ export function Sidebar({
               sub
               active={onHosts && hostFilter === g.groupId}
               onClick={() => ctx.goFiltered(g.groupId)}
+              onDropHosts={dropHostsOn(g.groupId, g.label)}
             />
           ))}
         </NavGroup>

--- a/client/src/shell/Shell.tsx
+++ b/client/src/shell/Shell.tsx
@@ -887,7 +887,17 @@ export function Sidebar({
   const tunnels = useApp((s) => s.tunnels);
   const hostFilter = useApp((s) => s.hostFilter);
   const moveHostsToGroup = useApp((s) => s.moveHostsToGroup);
+  const setGroupsNavVisible = useApp((s) => s.setGroupsNavVisible);
   const ctx = useCtx();
+
+  // Report whether the group list is actually on screen. The Hosts screen gates
+  // its drag on this: folded to the icon rail there are no group items, so
+  // there is nothing to drop on, and a host you can pick up but never put down
+  // is the affordance-that-can-only-fail this feature is at pains to avoid.
+  // Reported from here rather than computed there so it stays true by
+  // construction if the rail ever grows or loses a section.
+  const groupsShown = wide && !collapsed;
+  useEffect(() => setGroupsNavVisible(groupsShown), [groupsShown, setGroupsNavVisible]);
 
   // Drop of hosts dragged off the Hosts screen. The move itself is the store's,
   // unchanged — drag adds no membership rules of its own, so it and the menu

--- a/client/src/store/app.ts
+++ b/client/src/store/app.ts
@@ -271,6 +271,17 @@ interface AppStore {
    *  subscribes to this monotonic counter to react to every navigation. */
   routeSeq: number;
   device: Device;
+  /** Is the sidebar showing its GROUP list right now — i.e. wide enough for the
+   *  full sidebar and not collapsed by hand? Lives here only because ViewHosts
+   *  has to know: the group items are the drop targets for dragging a host into
+   *  a group, and with the sidebar folded to its icon rail there are none, so
+   *  the drag has to stop offering itself. App owns the two inputs (a width
+   *  breakpoint and a persisted toggle) and pushes the answer down.
+   *
+   *  Deliberately a BOOLEAN, not the sidebar's pixel width: App.tsx keeps the
+   *  width out of shared state because it changes on every frame of a resize.
+   *  This flips twice in the life of a drag. */
+  groupsNavVisible: boolean;
 
   // vault + data
   vaultId: string | null;
@@ -379,6 +390,7 @@ interface AppStore {
    *  navigates to the Known-hosts view. Shared by every review entry point. */
   reviewMismatch: (m: PendingMismatch) => void;
   setDevice: (d: Device) => void;
+  setGroupsNavVisible: (v: boolean) => void;
   setAutolockMin: (m: number | null) => void;
   setVault: (id: string) => Promise<void>;
   reloadVault: () => Promise<void>;
@@ -724,6 +736,7 @@ export const useApp = create<AppStore>((set, get) => ({
   route: "hosts", // always open on the all-hosts view (hostFilter defaults to HOST_FILTER_ALL)
   routeSeq: 0,
   device: lsDevice(),
+  groupsNavVisible: true,
   vaultId: null,
   vaults: [],
   hosts: [],
@@ -933,6 +946,11 @@ export const useApp = create<AppStore>((set, get) => ({
   runBack: () => get().backHandler?.() ?? false,
   reviewMismatch: (m) => {
     set((s) => ({ pendingMismatch: m, route: "known", routeSeq: s.routeSeq + 1, settingsOpen: false }));
+  },
+  setGroupsNavVisible: (v) => {
+    // Guarded: App pushes this on every render pass that could have changed it,
+    // and an unconditional set would notify every subscriber each time.
+    if (get().groupsNavVisible !== v) set({ groupsNavVisible: v });
   },
   setDevice: (d) => {
     // The panel only exists in the desktop shell, so carrying `settingsOpen`

--- a/client/src/support/hostDrag.test.ts
+++ b/client/src/support/hostDrag.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { draggedHostIds, hostDrag } from "./hostDrag";
+
+describe("draggedHostIds", () => {
+  it("carries the whole selection when the grabbed host is in it", () => {
+    expect(draggedHostIds("api", ["web", "api", "db"])).toEqual(["web", "api", "db"]);
+  });
+
+  it("carries only the grabbed host when it is outside the selection", () => {
+    // Grabbing a host that isn't selected moves that host — not the six others
+    // that happened to still be ticked, which the user would have to undo one
+    // by one.
+    expect(draggedHostIds("cache", ["web", "api", "db"])).toEqual(["cache"]);
+  });
+
+  it("carries the grabbed host when nothing is selected", () => {
+    expect(draggedHostIds("web", [])).toEqual(["web"]);
+  });
+
+  it("does not duplicate a selection of one that is the grabbed host", () => {
+    expect(draggedHostIds("web", ["web"])).toEqual(["web"]);
+  });
+
+  it("does not hand out the caller's selection array", () => {
+    // The payload outlives the render that produced it; sharing the array would
+    // let a later setSel mutation rewrite a drag already in flight.
+    const sel = ["web", "api"];
+    const carried = draggedHostIds("web", sel);
+    expect(carried).not.toBe(sel);
+  });
+});
+
+describe("hostDrag payload", () => {
+  beforeEach(() => hostDrag.clear());
+
+  it("is empty until a drag starts", () => {
+    expect(hostDrag.get()).toEqual([]);
+  });
+
+  it("holds what the drag set", () => {
+    hostDrag.set(["web", "api"]);
+    expect(hostDrag.get()).toEqual(["web", "api"]);
+  });
+
+  it("is empty again once cleared", () => {
+    // An Escape-cancelled or dropped-on-nothing drag ends here, so a later
+    // unrelated drop can't consume a stale payload.
+    hostDrag.set(["web"]);
+    hostDrag.clear();
+    expect(hostDrag.get()).toEqual([]);
+  });
+});

--- a/client/src/support/hostDrag.ts
+++ b/client/src/support/hostDrag.ts
@@ -1,0 +1,42 @@
+// Dragging hosts onto a group. Two things live here, both kept out of the views
+// so the Hosts screen (the drag source) and the sidebar (the drop target) cannot
+// disagree about what a drag is carrying: the payload, and the one rule that
+// decides what goes in it.
+//
+// The move itself is NOT here — `planGroupMove` / `moveHostsToGroup` already own
+// what "put these hosts in this group" means, and a second implementation of the
+// membership rules is exactly how drag and the menu would drift apart.
+
+/** The hosts currently being dragged. A module ref rather than `DataTransfer`
+ *  because the payload never leaves the app, and because DataTransfer's contents
+ *  are unreadable during `dragover` — which is precisely when a drop target has
+ *  to decide whether to light up. Same shape as the SFTP rows' `dragCtx`. */
+let dragged: string[] = [];
+
+export const hostDrag = {
+  set: (profileIds: string[]) => {
+    dragged = profileIds;
+  },
+  /** Empty when no host drag is in flight — a drop handler treats that as a
+   *  no-op, which is also what an Escape-cancelled drag leaves behind. */
+  get: (): string[] => dragged,
+  clear: () => {
+    dragged = [];
+  },
+};
+
+/** Marker put on the native DataTransfer. WebKit webviews (macOS/Linux) only
+ *  initiate a drag when the native data store is non-empty; the payload itself
+ *  lives in `hostDrag`, this only arms the gesture. */
+export const HOST_DRAG_MIME = "application/x-unissh-host";
+
+/** Which hosts a drag carries: the whole multi-selection when the host that was
+ *  picked up is part of it, otherwise just that host.
+ *
+ *  The second half is the point — grabbing a host OUTSIDE the selection moves
+ *  only what was grabbed. Moving six unrelated hosts because they happened to
+ *  still be selected is a data change the user never asked for, and one they'd
+ *  have to undo by hand six times. */
+export function draggedHostIds(grabbedId: string, selection: string[]): string[] {
+  return selection.includes(grabbedId) ? [...selection] : [grabbedId];
+}

--- a/client/src/views/ViewHosts.tsx
+++ b/client/src/views/ViewHosts.tsx
@@ -1395,9 +1395,12 @@ export function ViewHosts() {
   const narrow = useNarrow();
   const touch = useIsMobile();
   // A vertical drag on a phone is a scroll, so the phone shell never gets the
-  // attribute at all; with no groups there is nowhere to drop, and an affordance
-  // that can only fail is worse than none.
-  const canDragHosts = !touch && groups.length > 0;
+  // attribute at all. The other two conditions are the same rule twice: an
+  // affordance that can only fail is worse than none. With no groups there is
+  // nowhere to drop; with the sidebar folded to its icon rail the groups exist
+  // but none of them is on screen, so the drop targets do not either.
+  const groupsNavVisible = useApp((s) => s.groupsNavVisible);
+  const canDragHosts = !touch && groups.length > 0 && groupsNavVisible;
   const rowRef = useRef<HTMLDivElement | null>(null);
   const [rowW, setRowW] = useState(0);
   useEffect(() => {

--- a/client/src/views/ViewHosts.tsx
+++ b/client/src/views/ViewHosts.tsx
@@ -20,6 +20,7 @@ import type { ConnectionProfile } from "@/bridge/types";
 import { useTranslation, tDyn } from "@/i18n";
 import { nextRow } from "@/support/listNav";
 import { filterHosts, searchKeyAction } from "@/support/hostsSearch";
+import { HOST_DRAG_MIME, draggedHostIds, hostDrag } from "@/support/hostDrag";
 
 type SortKey = "name" | "added" | "connected";
 type RailTab = "detail" | "sessions";
@@ -54,6 +55,8 @@ function HostCard({
   onConnect,
   onSftp,
   onMenu,
+  draggable,
+  onDragStart,
 }: {
   h: ConnectionProfile;
   selected: boolean;
@@ -69,6 +72,9 @@ function HostCard({
   onConnect: () => void;
   onSftp: () => void;
   onMenu: (e: React.MouseEvent) => void;
+  /** Off on touch and when the vault has no groups — see ViewHosts. */
+  draggable?: boolean;
+  onDragStart?: (e: React.DragEvent) => void;
 }) {
   const p = usePalette();
   const { t, i18n } = useTranslation();
@@ -93,6 +99,8 @@ function HostCard({
       // and the filters do to this list.
       data-host-id={h.profileId}
       active={active || selected}
+      draggable={draggable}
+      onDragStart={onDragStart}
       onClick={onOpen}
       onDoubleClick={onConnect}
       onContextMenu={onMenu}
@@ -350,6 +358,8 @@ function HostRow({
   onOpen,
   onConnect,
   onMenu,
+  draggable,
+  onDragStart,
 }: {
   h: ConnectionProfile;
   selected: boolean;
@@ -362,6 +372,9 @@ function HostRow({
   onOpen: () => void;
   onConnect: () => void;
   onMenu: (e: React.MouseEvent) => void;
+  /** Off on touch and when the vault has no groups — see ViewHosts. */
+  draggable?: boolean;
+  onDragStart?: (e: React.DragEvent) => void;
 }) {
   const p = usePalette();
   const { t } = useTranslation();
@@ -376,6 +389,8 @@ function HostRow({
       tabIndex={0}
       data-host-id={h.profileId}
       aria-current={cursor ? "true" : undefined}
+      draggable={draggable}
+      onDragStart={onDragStart}
       onKeyDown={pressActivate(onOpen)}
       onFocus={() => setFocusIn(true)}
       onBlur={(e) => {
@@ -1339,6 +1354,26 @@ export function ViewHosts() {
   useMenu(sortOpen, () => setSortOpen(false), sortRef);
   const [sel, setSel] = useState<string[]>([]);
   const [open, setOpen] = useState<string | null>(hosts[0]?.profileId ?? null);
+  // Dragging a host onto a group files it there. The drop targets are the
+  // sidebar's group items (Shell) — on the desktop that IS the group UI; the
+  // chips in the strip below are the touch shell's stand-in for it, and touch
+  // has no drag to give them.
+  const beginHostDrag = (profileId: string, e: React.DragEvent) => {
+    hostDrag.set(draggedHostIds(profileId, sel));
+    try {
+      // The payload lives in hostDrag; this only arms the native gesture, which
+      // WebKit refuses to start with an empty data store. `move`, not `copy`: a
+      // host belongs to exactly one group, so the drop empties where it was.
+      e.dataTransfer.setData(HOST_DRAG_MIME, profileId);
+      e.dataTransfer.effectAllowed = "move";
+    } catch {
+      /* non-fatal */
+    }
+    // Covers every ending the drop handler doesn't: Escape, a drop on the
+    // toolbar, a drop on a tag chip. The browser fires dragend for all of them,
+    // and an empty payload is a no-op everywhere it is read.
+    window.addEventListener("dragend", () => hostDrag.clear(), { once: true });
+  };
   const [rail, setRail] = useState<RailTab>("detail");
   // The fixed-width detail rail would squish the list to a sliver when there isn't
   // room for both side by side, so render it as a full-width overlay instead. Trigger
@@ -1351,6 +1386,10 @@ export function ViewHosts() {
   // A 719px desktop window is narrow but NOT touch.
   const narrow = useNarrow();
   const touch = useIsMobile();
+  // A vertical drag on a phone is a scroll, so the phone shell never gets the
+  // attribute at all; with no groups there is nowhere to drop, and an affordance
+  // that can only fail is worse than none.
+  const canDragHosts = !touch && groups.length > 0;
   const rowRef = useRef<HTMLDivElement | null>(null);
   const [rowW, setRowW] = useState(0);
   useEffect(() => {
@@ -2285,6 +2324,8 @@ export function ViewHosts() {
                     e.preventDefault();
                     setMenu({ x: e.clientX, y: e.clientY, id: h.profileId, sub: false });
                   }}
+                  draggable={canDragHosts}
+                  onDragStart={(e) => beginHostDrag(h.profileId, e)}
                 />
               ))}
             </div>
@@ -2306,6 +2347,8 @@ export function ViewHosts() {
                     e.preventDefault();
                     setMenu({ x: e.clientX, y: e.clientY, id: h.profileId, sub: false });
                   }}
+                  draggable={canDragHosts}
+                  onDragStart={(e) => beginHostDrag(h.profileId, e)}
                 />
               ))}
             </div>

--- a/client/src/views/ViewHosts.tsx
+++ b/client/src/views/ViewHosts.tsx
@@ -14,6 +14,7 @@ import { pressActivate, useMenu } from "@/components/a11y";
 import { useApp, paneProfile, HOST_FILTER_ALL } from "@/store/app";
 import { useIsMobile, useNarrow } from "@/store/responsive";
 import { useCtx } from "@/store/ctx";
+import { writeText } from "@tauri-apps/plugin-clipboard-manager";
 import * as api from "@/bridge/api";
 import { profileAuthKind, apiErrorMessage } from "@/bridge/types";
 import type { ConnectionProfile } from "@/bridge/types";
@@ -21,6 +22,13 @@ import { useTranslation, tDyn } from "@/i18n";
 import { nextRow } from "@/support/listNav";
 import { filterHosts, searchKeyAction } from "@/support/hostsSearch";
 import { HOST_DRAG_MIME, draggedHostIds, hostDrag } from "@/support/hostDrag";
+
+/** The address as the list shows it — and, since dragging a card no longer lets
+ *  you select the text on it (a `draggable` element cannot be text-selected),
+ *  as "Copy address" puts it on the clipboard. One definition so the three can
+ *  never disagree; it also stops a host with no user rendering as `@10.0.0.1`. */
+const hostAddress = (h: ConnectionProfile): string =>
+  h.user ? `${h.user}@${h.host}` : h.host;
 
 type SortKey = "name" | "added" | "connected";
 type RailTab = "detail" | "sessions";
@@ -201,7 +209,7 @@ function HostCard({
           marginTop: 6,
         }}
       >
-        {h.user ? `${h.user}@${h.host}` : h.host}
+        {hostAddress(h)}
       </div>
 
       {/* L3 — status · auth (one mono line; colour only on meaning).
@@ -464,7 +472,7 @@ function HostRow({
           whiteSpace: "nowrap",
         }}
       >
-        {h.user}@{h.host}
+        {hostAddress(h)}
       </span>
       <div style={{ display: "flex", gap: 5, width: 130, flexShrink: 0, overflow: "hidden", alignItems: "center" }}>
         {h.tags.slice(0, 2).map((tg) => (
@@ -2619,6 +2627,19 @@ export function ViewHosts() {
           : [
               { icon: "terminal", label: t("hosts.connect"), onClick: () => ctx.connect(mh) },
               { icon: "folders", label: t("nav.sftp"), onClick: () => void ctx.connectSftp(mh) },
+              {
+                icon: "copy",
+                label: t("hosts.menu.copyAddress"),
+                // Dragging a card is what took the old way of getting this out
+                // of the screen — you cannot select text on a `draggable`
+                // element. This is better than what it replaces: it works in the
+                // row layout too, where the address is ellipsised, and it does
+                // not depend on hitting 12px of mono type with the pointer.
+                onClick: () =>
+                  void writeText(hostAddress(mh))
+                    .then(() => ctx.toast(t("hosts.addressCopied"), "ok"))
+                    .catch((e) => ctx.toast(apiErrorMessage(e), "err")),
+              },
               {
                 icon: "folder",
                 label: t("hosts.menu.addToGroup"),


### PR DESCRIPTION
Closes #51.

Putting a host in a group was menu-only — overflow menu → "Move to group" → pick
the target, repeated once per host — in an app where every other rearrangeable
list is dragged. Now you pick up a host card or row and drop it on a group.

## What lands

- **Drag source**: `HostCard` and `HostRow` both take `draggable` + `onDragStart`.
  Off on the phone shell (a vertical drag there is a scroll) and off when the
  vault has no groups, so the affordance never appears where it could only fail.
- **`client/src/support/hostDrag.ts`** — the payload plus the one genuine decision
  in the feature:
  - the payload is a module ref, like the SFTP rows' `dragCtx`. `DataTransfer`
    carries only a marker: its contents are unreadable during `dragover`, which is
    exactly when a target has to decide whether to light up.
  - `draggedHostIds(grabbedId, selection)` → the whole selection when the grabbed
    host is in it, otherwise just the grabbed host. Grabbing a host *outside* the
    selection must not move six others.
- **Drop** → the existing `moveHostsToGroup` / `planGroupMove`, unchanged. Drag
  adds no membership rules of its own, so it and the menu cannot disagree about
  what filing a host means; the action's `false` return ("nothing would change")
  is what keeps a drop on the host's current group from writing or reloading.
- `hosts.bulk.movedToGroup` toast (en + ru); failures reuse the menu's
  `apiErrorMessage` toast.

## One deviation from the issue

The issue specifies the group chips in the Hosts filter strip as the drop
targets, "not a sidebar". Those chips render **only on touch** —
`ViewHosts.tsx` gates them on `useIsMobile()`, with a comment saying the desktop
Sidebar owns group scoping — and touch is where the issue (rightly) excludes
drag. Following that literally would have shipped a gesture with no target it
could ever reach, so the drop targets are the sidebar's group items instead.
The touch chips are untouched.

Two smaller notes on the same theme:
- The issue says mobile is excluded "by construction … no runtime platform check
  inside the shared row component" because the mobile shell renders its own host
  list. That fork was deleted in #59 — `MobileApp` renders `ViewHosts` — so the
  exclusion is one `!touch` in `ViewHosts`, not in the row components.
- With the sidebar folded to its icon rail (window < 880px, or collapsed by
  hand) there are no group items and therefore no drop targets. The menu path
  still works. Worth a follow-up if it bites.

## Tests

`client/src/support/hostDrag.test.ts` — `draggedHostIds` over the four cases the
issue names, plus that it doesn't hand out the caller's array (the payload
outlives the render that produced it) and the payload's set/get/clear. The
membership consequences are already covered by `groupMove.test.ts` and are not
duplicated. `lint` + `typecheck` + 479 tests green.

## Manual pass

Driven in a headless browser against a stubbed bridge, both layouts:

| | |
|---|---|
| card layout, list layout | drag lands in both |
| multi-select, drag one of them | whole selection moves |
| drag a host *not* in the selection | only that host moves |
| drop on the host's own group | no write, no reload, no toast |
| drop on "All hosts" / a tag chip / empty space | nothing, silently |
| Escape mid-drag | nothing written, highlight clears |
| filtered to a group, drag a member out | row disappears at once |
| vault with no groups | `draggable` is false |

Two defects turned up that way and are fixed in this branch: the highlight
blinked as the pointer crossed the item's own icon/label (`dragleave` fires on
a transition to a child), and it stayed lit after an Escape (`dragleave` is not
fired for a drag that *ends* over the item — `dragend` on the window is).

Still owed on a real machine: a pass on macOS/Windows WebViews, and a phone
check that the host list still scrolls.