### PR TITLE
feat(deploy): make the published host ports overridable in the base compose stacks

### DIFF
--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -23,7 +23,8 @@
 #   docker buildx imagetools inspect ghcr.io/goduni/unissh-server:latest
 #
 # Topology (identical to compose.yml):
-#   caddy   -> the ONLY host-exposed service (80/443 + 443/udp). Terminates TLS
+#   caddy   -> the ONLY host-exposed service (80/443 + 443/udp by default; move
+#              them with UNISSH_HTTP_PORT / UNISSH_HTTPS_PORT). Terminates TLS
 #              (ACME or internal CA), serves the SPA same-origin and
 #              reverse-proxies the API (/v1, /healthz, /readyz) to the server
 #              over the compose network.
@@ -53,9 +54,15 @@ services:
     depends_on:
       - server
     ports:
-      - "80:80"
-      - "443:443"
-      - "443:443/udp"   # HTTP/3 (QUIC)
+      # Host side only. The CONTAINER side never moves: Caddy still listens on
+      # 80/443 inside, so the Caddyfile, the compose network and every override
+      # in deploy/ are unaffected. Unset => 80/443, exactly as before.
+      # Moving the HTTP port breaks ACME's HTTP-01 challenge unless the real
+      # public :80 is forwarded to it — see "Port 80 or 443 already in use" in
+      # deploy/README.md.
+      - "${UNISSH_HTTP_PORT:-80}:80"
+      - "${UNISSH_HTTPS_PORT:-443}:443"
+      - "${UNISSH_HTTPS_PORT:-443}:443/udp"   # HTTP/3 (QUIC) — follows HTTPS
     environment:
       # Site address. Real domain => automatic ACME. A *.local host or an IP,
       # combined with UNISSH_TLS_MODE=internal, => Caddy internal CA (self-signed).

--- a/compose.yml
+++ b/compose.yml
@@ -12,7 +12,8 @@
 #                        (path-dep ../../rust-core/crates/crypto) + the Vite SPA.
 #
 # Topology:
-#   caddy   -> the ONLY host-exposed service (80/443). Terminates TLS (ACME or
+#   caddy   -> the ONLY host-exposed service (80/443 by default; move them with
+#              UNISSH_HTTP_PORT / UNISSH_HTTPS_PORT). Terminates TLS (ACME or
 #              internal CA), serves the SPA same-origin and reverse-proxies the
 #              API (/v1, /healthz, /readyz) to the server over the compose net.
 #   server  -> plain HTTP on the INTERNAL network only (NOT host-published).
@@ -44,9 +45,15 @@ services:
     depends_on:
       - server
     ports:
-      - "80:80"
-      - "443:443"
-      - "443:443/udp"   # HTTP/3 (QUIC)
+      # Host side only. The CONTAINER side never moves: Caddy still listens on
+      # 80/443 inside, so the Caddyfile, the compose network and every override
+      # in deploy/ are unaffected. Unset => 80/443, exactly as before.
+      # Moving the HTTP port breaks ACME's HTTP-01 challenge unless the real
+      # public :80 is forwarded to it — see "Port 80 or 443 already in use" in
+      # deploy/README.md.
+      - "${UNISSH_HTTP_PORT:-80}:80"
+      - "${UNISSH_HTTPS_PORT:-443}:443"
+      - "${UNISSH_HTTPS_PORT:-443}:443/udp"   # HTTP/3 (QUIC) — follows HTTPS
     environment:
       # Site address. Real domain => automatic ACME. A *.local host or an IP,
       # combined with UNISSH_TLS_MODE=internal, => Caddy internal CA (self-signed).

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -41,8 +41,9 @@ UNISSH_TLS_DIRECTIVE=tls admin@example.com
 # answered on the REAL public port 80. The way out depends on who owns that port
 # (see deploy/README.md): forward public :80 to your port UPSTREAM if this host
 # is not the edge; if another HTTP server on THIS host owns it, have that server
-# proxy ONLY /.well-known/acme-challenge/* to your port — do not NAT-redirect
-# all of :80, that hijacks it; or use a TLS mode with no challenge at all
+# PROXY (not redirect — ACME accepts redirects only to ports 80/443) ONLY
+# /.well-known/acme-challenge/* to your port, and do not NAT-redirect all of
+# :80, that hijacks it; or use a TLS mode with no challenge at all
 # ("tls internal", or certificate files via deploy/compose.tls-files.yml).
 # Already have a proxy in front? deploy/compose.behind-proxy.yml beats these
 # vars — nothing has to move.

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -38,10 +38,14 @@ UNISSH_TLS_DIRECTIVE=tls admin@example.com
 # listens on 80/443, so nothing else in the stack changes.
 #
 # CAVEAT — moving the HTTP port breaks automatic ACME: the HTTP-01 challenge is
-# answered on the REAL public port 80. Either forward the host's :80 to the port
-# you pick, or use a TLS mode that needs no challenge ("tls internal", or
-# certificate files via deploy/compose.tls-files.yml). Already have a proxy in
-# front? deploy/compose.behind-proxy.yml is the better answer than these vars.
+# answered on the REAL public port 80. The way out depends on who owns that port
+# (see deploy/README.md): forward public :80 to your port UPSTREAM if this host
+# is not the edge; if another HTTP server on THIS host owns it, have that server
+# proxy ONLY /.well-known/acme-challenge/* to your port — do not NAT-redirect
+# all of :80, that hijacks it; or use a TLS mode with no challenge at all
+# ("tls internal", or certificate files via deploy/compose.tls-files.yml).
+# Already have a proxy in front? deploy/compose.behind-proxy.yml beats these
+# vars — nothing has to move.
 # Check the result before starting:  docker compose config | grep -A1 published
 # UNISSH_HTTP_PORT=80
 # UNISSH_HTTPS_PORT=443

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -31,6 +31,21 @@ UNISSH_DOMAIN=unissh.example.com
 #                                -f deploy/compose.tls-files.yml up -d
 UNISSH_TLS_DIRECTIVE=tls admin@example.com
 
+# OPTIONAL — the HOST ports Caddy publishes. Defaults are 80 and 443; set these
+# only when something else on the host already owns one of them. Port numbers
+# only (no interface prefix). The HTTPS value also moves the HTTP/3 (QUIC) UDP
+# mapping, so the two can never drift apart. Inside the container Caddy still
+# listens on 80/443, so nothing else in the stack changes.
+#
+# CAVEAT — moving the HTTP port breaks automatic ACME: the HTTP-01 challenge is
+# answered on the REAL public port 80. Either forward the host's :80 to the port
+# you pick, or use a TLS mode that needs no challenge ("tls internal", or
+# certificate files via deploy/compose.tls-files.yml). Already have a proxy in
+# front? deploy/compose.behind-proxy.yml is the better answer than these vars.
+# Check the result before starting:  docker compose config | grep -A1 published
+# UNISSH_HTTP_PORT=80
+# UNISSH_HTTPS_PORT=443
+
 # Only used by deploy/compose.traefik.yml (publishing through a Traefik you
 # already run): the Docker network your traefik container is on, the hostname to
 # route, and the certresolver it should use.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -150,12 +150,21 @@ targets the site address with no port, so browse the HTTPS port directly.
 
 > **Moving the HTTP port breaks automatic ACME.** The HTTP-01 challenge is
 > answered on the **real** public port 80 and no redirect to another port is
-> followed, so the certificate silently never issues. Two ways out:
-> - forward the host's real `:80` to the port you picked, outside Compose —
->   e.g. `iptables -t nat -A PREROUTING -p tcp --dport 80 -j REDIRECT --to-port 8080`
->   (or the equivalent NAT rule upstream); or
-> - use a TLS mode that needs no challenge: `UNISSH_TLS_DIRECTIVE="tls internal"`
->   for a LAN host, or certificate files you already hold via
+> followed, so the certificate silently never issues. What to do depends on
+> *what* owns port 80:
+> - **Nothing on this host** — the host is not the edge, or the conflict is
+>   elsewhere. Forward public `:80` to your chosen port upstream (router, NAT
+>   rule, cloud load balancer). The challenge arrives on the moved port and
+>   succeeds.
+> - **Another HTTP server on this host** (nginx, Apache, another Caddy — the
+>   usual reason you are here). Point *only* `/.well-known/acme-challenge/*` at
+>   your chosen HTTP port from that server. Do **not** NAT-redirect all of `:80`
+>   to it: that hijacks the traffic of the service that owns the port. And weigh
+>   `compose.behind-proxy.yml` first — a proxy already terminating TLS for other
+>   sites can do it for this one, and then no port has to move at all.
+> - **Neither is workable** — use a TLS mode that needs no challenge:
+>   `UNISSH_TLS_DIRECTIVE="tls internal"` for a LAN host, or certificate files
+>   obtained some other way (DNS-01, a commercial cert) via
 >   `compose.tls-files.yml`.
 >
 > Moving **only** `UNISSH_HTTPS_PORT` is safe for ACME — HTTP-01 still runs on

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -176,6 +176,21 @@ targets the site address with no port, so browse the HTTPS port directly.
 > Moving **only** `UNISSH_HTTPS_PORT` is safe for ACME — HTTP-01 still runs on
 > 80. (TLS-ALPN-01, which would need 443, simply stops being an option.)
 
+The nginx form of the second case, on the server that holds `:80`:
+
+```nginx
+location /.well-known/acme-challenge/ {
+    proxy_pass http://127.0.0.1:8080;   # your UNISSH_HTTP_PORT
+    proxy_set_header Host $host;
+}
+```
+
+The `Host` line is load-bearing. Drop it and the request reaches Caddy as
+`Host: 127.0.0.1:8080`, which matches no site it serves, so it answers the
+challenge with a redirect elsewhere and validation fails — with a connection
+error that says nothing about the header. Both outcomes were reproduced against
+a local ACME server before this was written.
+
 If the reason 443 is busy is that **you already run a proxy there**, these
 variables are the wrong tool: use `compose.behind-proxy.yml` and let that proxy
 terminate TLS in front of the stack — see *Other front doors* just below.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -141,27 +141,33 @@ take a **port number** (not an interface prefix — for loopback-only use
 ports. Only the host side moves: inside the container Caddy still listens on
 80/443, so the Caddyfile and every override in this folder are untouched. (One
 visible consequence of that: Caddy advertises HTTP/3 as `alt-svc: h3=":443"`,
-the port it listens on inside, so browsers reaching a moved HTTPS port quietly
-stay on HTTP/2. Nothing breaks; the UDP mapping is published either way.)
+the port it listens on inside. `Alt-Svc` is an optional hint — a client that
+cannot reach h3 there just keeps the connection it already has
+([RFC 7838](https://www.rfc-editor.org/rfc/rfc7838.html)) — so a browser on a
+moved HTTPS port stays on HTTP/2. The UDP mapping is published either way.)
 
 Set `UNISSH__SERVER__PUBLIC_URL=https://<domain>:8443` to match, or invite links
 come out pointing at the port you no longer serve. Caddy's HTTP→HTTPS redirect
 targets the site address with no port, so browse the HTTPS port directly.
 
-> **Moving the HTTP port breaks automatic ACME.** The HTTP-01 challenge is
-> answered on the **real** public port 80 and no redirect to another port is
-> followed, so the certificate silently never issues. What to do depends on
-> *what* owns port 80:
+> **Moving the HTTP port breaks automatic ACME.** The challenge GET "MUST be
+> sent to TCP port 80"
+> ([RFC 8555 §8.3](https://www.rfc-editor.org/rfc/rfc8555.html#section-8.3)),
+> and Let's Encrypt follows redirects "only to ports 80 or 443"
+> ([Challenge Types](https://letsencrypt.org/docs/challenge-types/)) — so the
+> obvious fix, a 301 from the busy port to the one you picked, does **not**
+> work either. What does depends on *what* owns port 80:
 > - **Nothing on this host** — the host is not the edge, or the conflict is
 >   elsewhere. Forward public `:80` to your chosen port upstream (router, NAT
 >   rule, cloud load balancer). The challenge arrives on the moved port and
 >   succeeds.
 > - **Another HTTP server on this host** (nginx, Apache, another Caddy — the
->   usual reason you are here). Point *only* `/.well-known/acme-challenge/*` at
->   your chosen HTTP port from that server. Do **not** NAT-redirect all of `:80`
->   to it: that hijacks the traffic of the service that owns the port. And weigh
->   `compose.behind-proxy.yml` first — a proxy already terminating TLS for other
->   sites can do it for this one, and then no port has to move at all.
+>   usual reason you are here). Have it **proxy** `/.well-known/acme-challenge/*`
+>   to your chosen HTTP port — a proxy_pass, not a redirect, per the port rule
+>   above. Do not NAT-redirect all of `:80` either: that hijacks the traffic of
+>   the service that owns the port. And weigh `compose.behind-proxy.yml` first —
+>   a proxy already terminating TLS for other sites can do it for this one, and
+>   then no port has to move at all.
 > - **Neither is workable** — use a TLS mode that needs no challenge:
 >   `UNISSH_TLS_DIRECTIVE="tls internal"` for a LAN host, or certificate files
 >   obtained some other way (DNS-01, a commercial cert) via

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -25,6 +25,7 @@ docker compose up -d --build
 ```
 
 - Only **Caddy** publishes host ports: **80** and **443** (443/udp for HTTP/3).
+  One of them already taken? See [Port 80 or 443 already in use](#port-80-or-443-already-in-use).
 - The server is **never** host-published; Caddy reaches it as `http://server:8443`.
 - Migrations auto-apply on boot (SQLite). The SPA is served same-origin, so the
   admin panel and its API share one origin (CORS stays off).
@@ -113,6 +114,56 @@ TLS is controlled by a single env knob, `UNISSH_TLS_DIRECTIVE`:
   `skip_install_trust` in the Caddyfile.
 
 The `caddy-data` volume persists issued certs / the internal CA root — keep it.
+
+## Port 80 or 443 already in use
+
+The published ports are variables, so a host that already serves something on
+80 or 443 is a two-line `.env` change rather than a fork of a tracked compose
+file:
+
+```bash
+# .env
+UNISSH_HTTP_PORT=8080
+UNISSH_HTTPS_PORT=8443
+```
+
+```bash
+docker compose config | grep -B1 -A2 published   # resolved mapping, nothing started
+docker compose up -d
+curl -kI https://<UNISSH_DOMAIN>:8443/readyz
+```
+
+Both default to today's values, so a stack that sets neither publishes exactly
+what it always did. They work the same in `compose.yml` and `compose.prod.yml`,
+take a **port number** (not an interface prefix — for loopback-only use
+`compose.behind-proxy.yml` below), and `UNISSH_HTTPS_PORT` carries the HTTP/3
+(QUIC) UDP mapping with it, so HTTPS and HTTP/3 can never land on different
+ports. Only the host side moves: inside the container Caddy still listens on
+80/443, so the Caddyfile and every override in this folder are untouched. (One
+visible consequence of that: Caddy advertises HTTP/3 as `alt-svc: h3=":443"`,
+the port it listens on inside, so browsers reaching a moved HTTPS port quietly
+stay on HTTP/2. Nothing breaks; the UDP mapping is published either way.)
+
+Set `UNISSH__SERVER__PUBLIC_URL=https://<domain>:8443` to match, or invite links
+come out pointing at the port you no longer serve. Caddy's HTTP→HTTPS redirect
+targets the site address with no port, so browse the HTTPS port directly.
+
+> **Moving the HTTP port breaks automatic ACME.** The HTTP-01 challenge is
+> answered on the **real** public port 80 and no redirect to another port is
+> followed, so the certificate silently never issues. Two ways out:
+> - forward the host's real `:80` to the port you picked, outside Compose —
+>   e.g. `iptables -t nat -A PREROUTING -p tcp --dport 80 -j REDIRECT --to-port 8080`
+>   (or the equivalent NAT rule upstream); or
+> - use a TLS mode that needs no challenge: `UNISSH_TLS_DIRECTIVE="tls internal"`
+>   for a LAN host, or certificate files you already hold via
+>   `compose.tls-files.yml`.
+>
+> Moving **only** `UNISSH_HTTPS_PORT` is safe for ACME — HTTP-01 still runs on
+> 80. (TLS-ALPN-01, which would need 443, simply stops being an option.)
+
+If the reason 443 is busy is that **you already run a proxy there**, these
+variables are the wrong tool: use `compose.behind-proxy.yml` and let that proxy
+terminate TLS in front of the stack — see *Other front doors* just below.
 
 ## Other front doors
 


### PR DESCRIPTION
Closes #59.

`compose.yml` and `compose.prod.yml` hard-coded Caddy's published ports, so an operator whose host already serves something on 80 or 443 had to edit a tracked file — turning it into a local fork and a merge conflict at every upgrade. The host side of each mapping is now a variable with today's value as the default:

```yaml
- "${UNISSH_HTTP_PORT:-80}:80"
- "${UNISSH_HTTPS_PORT:-443}:443"
- "${UNISSH_HTTPS_PORT:-443}:443/udp"
```

`UNISSH_HTTPS_PORT` carries the QUIC/UDP mapping with it, so HTTP/3 can never end up on a different port than HTTPS. Container-side ports do not move, so the Caddyfile, the internal network and every override in `deploy/` are untouched.

Docs: both variables land in `deploy/.env.example` (commented out at their defaults, in the Caddy/TLS section next to `UNISSH_DOMAIN`), and `deploy/README.md` gains a **"Port 80 or 443 already in use"** section ahead of *Other front doors* — naming the variables, stating the ACME caveat with its two ways out, and pointing an operator who actually wants their own proxy in front at `compose.behind-proxy.yml` instead.

## Verification

All rendering checked with `docker compose config` (Compose v5.0.2), which resolves variables without starting anything.

**Defaults are byte-identical to before.** `diff` of the rendered config at `main` vs. this branch, with no variables set — both base stacks *and* every override, all ten combinations:

```
IDENTICAL  compose.yml                      IDENTICAL  compose.prod.yml
IDENTICAL  compose.yml + behind-proxy       IDENTICAL  compose.prod.yml + behind-proxy
IDENTICAL  compose.yml + traefik            IDENTICAL  compose.prod.yml + traefik
IDENTICAL  compose.yml + reverse-proxy      IDENTICAL  compose.prod.yml + reverse-proxy
IDENTICAL  compose.yml + tls-files          IDENTICAL  compose.prod.yml + tls-files
```

**Variables take effect, in both stacks, and one alone leaves the other at its default:**

| `.env` | rendered `caddy` ports (identical for `compose.yml` and `compose.prod.yml`) |
|---|---|
| *(nothing set)* | `80:80/tcp`, `443:443/tcp`, `443:443/udp` |
| `UNISSH_HTTP_PORT=8080` `UNISSH_HTTPS_PORT=8443` | `8080:80/tcp`, `8443:443/tcp`, `8443:443/udp` |
| `UNISSH_HTTP_PORT=8080` only | `8080:80/tcp`, `443:443/tcp`, `443:443/udp` |
| `UNISSH_HTTPS_PORT=8443` only | `80:80/tcp`, `8443:443/tcp`, `8443:443/udp` |

**Overrides stay inert, with the variables set** — the `!override` cases are the ones that matter:

| override | rendered, with `8080`/`8443` set |
|---|---|
| `compose.behind-proxy.yml` | `127.0.0.1:8080:80/tcp` only — `!override` still replaces the whole block |
| `compose.traefik.yml` | nothing published — `!override []` still wins |
| `compose.reverse-proxy.yml` | `server` on `127.0.0.1:8443:8443`; caddy profile-gated off |
| `compose.tls-files.yml` | `8080:80`, `8443:443`, `8443:443/udp` — does not touch ports, so the variables apply |

**Real bring-up on non-default ports**, `compose.prod.yml` with `tls internal`, an isolated project name and ports `18080`/`18444` (this host's 8443 is taken):

```
unissh-portcheck-caddy-1  running  0.0.0.0:18080->80/tcp, 0.0.0.0:18444->443/tcp, 0.0.0.0:18444->443/udp

https://localhost:18444/readyz  -> 200
https://localhost:18444/        -> 200  <title>UniSSH Admin</title>  /assets/index-CZCs7dgD.js
https://localhost:18444/spaces  -> 200  (SPA history fallback)
http://localhost:18080/         -> 308  Location: https://localhost/
```

Stack torn down with `down -v` afterwards. ACME is not exercised — the documented caveat is the deliverable there.

Two behaviours that bring-up confirmed and that the README now states rather than leaves to be discovered: Caddy's HTTP→HTTPS redirect targets the site address **without** a port (browse the HTTPS port directly), and `alt-svc: h3=":443"` advertises the container-internal port, so a browser on a moved HTTPS port quietly stays on HTTP/2.

## Out of scope

Per the narrowed issue: no changes to any override file, no interface-binding syntax (`compose.behind-proxy.yml` covers loopback-only properly), no change to TLS mode selection, ACME behaviour or the Caddyfile.